### PR TITLE
Add junior handbook and update dates and times for 2023/24 season

### DIFF
--- a/src/cshc/templates/club_info/juniors.html
+++ b/src/cshc/templates/club_info/juniors.html
@@ -75,7 +75,7 @@
           <tr>
             <td class="jnr-table--heading">Time</td>
             <td class="jnr-table--details">
-              U8 - U10 (years 2 - 5): Saturdays, 9am - 10am<br />
+              U8 - U10 (years 2 - 5): Saturdays, 8:45am - 10am<br />
               U12 Boys (years 6 &amp; 7) and U14 Boys (years 8 &amp; 9): Tuesdays, 6:15pm - 7:30pm<br />
               U12 Girls and U14 Girls: Wednesdays, 6:15pm - 7:30pm
             </td>
@@ -83,18 +83,18 @@
           <tr>
             <td class="jnr-table--heading">Dates</td>
             <td class="jnr-table--details">
-              <div class="jnr-table--title">2022/23</div><br/>
+              <div class="jnr-table--title">2023/24</div><br/>
               <div class="jnr-table--heading">Autumn term (12 weeks)</div>
               <div class="jnr-table--context">
-                U8 - U10: 10 September - 10 December (half term break 22 &amp; 29 October)<br />
-                U12 &amp; U14 Boys: 13 September - 6 December (half term break 25 October)<br />
-                U12 &amp; U14 Girls: 14 September - 7 December (half term break 26 October)
+                U8 - U10: 9 September - 9 December (half term break 21 &amp; 28 October)<br />
+                U12 &amp; U14 Boys: 12 September - 5 December (half term break 24 October)<br />
+                U12 &amp; U14 Girls: 13 September - 6 December (half term break 25 October)
               </div><br/>
               <div class="jnr-table--heading">Spring term (10 weeks)</div>
               <div class="jnr-table--context">
-                U8 - U10: 7 January - 25 March (half term break 11 &amp; 18 February)<br />
-                U12 &amp; U14 Boys: 10 January - 21 March (half term break 14 February)<br />
-                U12 &amp; U14 Girls: 11 January - 22 March (half term break 15 February)
+                U8 - U10: 13 January - 30 March (half term break 17 &amp; 24 February)<br />
+                U12 &amp; U14 Boys: 16 January - 26 March (half term break 20 February)<br />
+                U12 &amp; U14 Girls: 17 January - 27 March (half term break 21 February)
               </div>
             </td>
           </tr>
@@ -220,6 +220,7 @@
       {% document title="Reporting concerns about a child's welfare" category="Juniors" %}
       {% document title="Photography Best Practice Guidance" category="Juniors" %}
       {% document title="RESPECT - Code of Ethics and Behaviour" category="Juniors" %}
+      {% document title="Junior handbook" category="Juniors" %}
     </div>
     <div id="calendar" class="col-md-6 col-lg-4">
       <span class="float-right">


### PR DESCRIPTION
1. Add a link to the new junior handbook document.
2. Update training dates for 2023/24 season.
3. Bring start time of Saturdays to 8:45am to align with midweek message.