### PR TITLE
Update ahead of the 2024-25 season

### DIFF
--- a/src/core/views.py
+++ b/src/core/views.py
@@ -146,7 +146,6 @@ class JuniorsContactSubmissionCreateView(CreateView):
         context['sub_nav_items'] = [
             {'id': 'contact-us', 'label': 'Get In Touch'},
             {'id': 'resources', 'label': 'Resources'},
-            {'id': 'calendar', 'label': 'Calendar'},
             {'id': 'key_people', 'label': 'Key People'},
             {'id': 'news', 'label': 'News'},
         ]

--- a/src/cshc/templates/club_info/directions.html
+++ b/src/cshc/templates/club_info/directions.html
@@ -15,6 +15,7 @@
 {% url 'venue_detail' 'cantabs' as cantabs_url %}
 {% url 'venue_detail' 'queen-edith' as queen_edith_url %}
 {% url 'venue_detail' 'long-road' as long_road_url %}
+{% url 'venue_detail' 'st-marys' as st_marys_url %}
 {% url 'venue_list' as venues_url %}
 
 {% heading "Directions" %}
@@ -22,7 +23,8 @@
 <div id="home-venues" class="g-pb-20">
   {% subheading "Home Venues" %}
 
-  <p class="lead">We train and play our home matches at <a href="{{ long_road_url }}" title="Pitch details...">Long Road Sixth Form College</a> in south Cambridge.</p>
+  <p class="lead">We train and play our home matches at <a href="{{ long_road_url }}" title="Pitch details...">Long Road Sixth Form College</a> and 
+    <a href="{{ st_marys_url }}" title="Venue details">St Mary's & Homerton Sports Ground</a> in south Cambridge.</p>
 
   <iframe src="https://www.google.com/maps/d/embed?mid=1lIfraO305IegNjXDKFhx0G1EtIdhPxvI" width="100%" height="480"></iframe>
 </div>

--- a/src/cshc/templates/club_info/directions.html
+++ b/src/cshc/templates/club_info/directions.html
@@ -23,7 +23,7 @@
 <div id="home-venues" class="g-pb-20">
   {% subheading "Home Venues" %}
 
-  <p class="lead">We train and play our home matches at <a href="{{ long_road_url }}" title="Pitch details...">Long Road Sixth Form College</a> and 
+  <p class="lead">We train and play our home matches at <a href="{{ long_road_url }}" title="Pitch details...">Long Road Sixth Form College</a> and
     <a href="{{ st_marys_url }}" title="Venue details">St Mary's & Homerton Sports Ground</a> in south Cambridge.</p>
 
   <iframe src="https://www.google.com/maps/d/embed?mid=1lIfraO305IegNjXDKFhx0G1EtIdhPxvI" width="100%" height="480"></iframe>
@@ -32,8 +32,8 @@
 <div id="away-matches" class="g-pb-20">
   {% subheading "Away Matches" %}
 
-  <p class="lead">Details of the pitch locations of the clubs we play against can be found on the <a href="{{ venues_url }}">Venues</a> page.</p> 
-  <p class="lead">Alternatively, a full list of all club astro pitches in the East Region with directions to them can be 
+  <p class="lead">Details of the pitch locations of the clubs we play against can be found on the <a href="{{ venues_url }}">Venues</a> page.</p>
+  <p class="lead">Alternatively, a full list of all club astro pitches in the East Region with directions to them can be
     found <a href="http://www.east-hockey.com/clubs/clubastrosearch.asp" target="_blank">here</a>.</p>
 </div>
 

--- a/src/cshc/templates/club_info/juniors.html
+++ b/src/cshc/templates/club_info/juniors.html
@@ -60,8 +60,8 @@
     alongside their age-group based hockey, from age 13 upwards.
   </p>
   <p class="lead">
-    Each age group play matches at different levels to make sure there is competitive hockey for all our players. Development tournaments are very friendly occasions that 
-    enable new or less experienced players to play matches against similarly skilled opposition. Stronger players from U10 upwards also play against local clubs at a 
+    Each age group play matches at different levels to make sure there is competitive hockey for all our players. Development tournaments are very friendly occasions that
+    enable new or less experienced players to play matches against similarly skilled opposition. Stronger players from U10 upwards also play against local clubs at a
     higher level. This gives our players excellent opportunities to develop their hockey. Note that fixtures are almost always on Sundays and are in addition to training.
   </p>
   <p class="lead">
@@ -93,7 +93,7 @@
             <td class="jnr-table--details">
               U12 Boys (years 6 &amp; 7) and U14 Boys (years 8 &amp; 9): Tuesdays, 6:15pm - 7:30pm
             </td>
-          </tr>          
+          </tr>
           <tr>
             <td class="jnr-table--heading">Dates</td>
             <td class="jnr-table--details">

--- a/src/cshc/templates/club_info/juniors.html
+++ b/src/cshc/templates/club_info/juniors.html
@@ -60,6 +60,11 @@
     alongside their age-group based hockey, from age 13 upwards.
   </p>
   <p class="lead">
+    Each age group play matches at different levels to make sure there is competitive hockey for all our players. Development tournaments are very friendly occasions that 
+    enable new or less experienced players to play matches against similarly skilled opposition. Stronger players from U10 upwards also play against local clubs at a 
+    higher level. This gives our players excellent opportunities to develop their hockey. Note that fixtures are almost always on Sundays and are in addition to training.
+  </p>
+  <p class="lead">
     We offer a <strong>free 3 session taster</strong> for new players to try out without commitment. The subscription fee is due your fourth
     session - if you decide not to continue beyond your first 3 sessions there is nothing to pay!
   </p>
@@ -76,25 +81,34 @@
             <td class="jnr-table--heading">Time</td>
             <td class="jnr-table--details">
               U8 - U10 (years 2 - 5): Saturdays, 8:45am - 10am<br />
-              U12 Boys (years 6 &amp; 7) and U14 Boys (years 8 &amp; 9): Tuesdays, 6:15pm - 7:30pm<br />
-              U12 Girls and U14 Girls: Wednesdays, 6:15pm - 7:30pm
+              U12 Girls (years 6 &amp; 7) and U14 Girls (years 8 &amp; 9): Tuesdays, 6:15pm - 7:30pm
             </td>
           </tr>
           <tr>
+            <td class="jnr-table--heading">Location</td>
+            <td class="jnr-table--details"><a href="{{ st_marys_url }}" title="Pitch details">St Mary's & Homerton Sports Ground</a></td>
+          </tr>
+          <tr>
+            <td class="jnr-table--heading">Time</td>
+            <td class="jnr-table--details">
+              U12 Boys (years 6 &amp; 7) and U14 Boys (years 8 &amp; 9): Tuesdays, 6:15pm - 7:30pm
+            </td>
+          </tr>          
+          <tr>
             <td class="jnr-table--heading">Dates</td>
             <td class="jnr-table--details">
-              <div class="jnr-table--title">2023/24</div><br/>
+              <div class="jnr-table--title">2024/25</div><br/>
               <div class="jnr-table--heading">Autumn term (12 weeks)</div>
               <div class="jnr-table--context">
-                U8 - U10: 9 September - 9 December (half term break 21 &amp; 28 October)<br />
-                U12 &amp; U14 Boys: 12 September - 5 December (half term break 24 October)<br />
-                U12 &amp; U14 Girls: 13 September - 6 December (half term break 25 October)
+                U8 - U10: 7 September - 7 December (half term break 26 October &amp; 2 November)<br />
+                U12 &amp; U14 Boys: 10 September - 3 December (half term break 29 October)<br />
+                U12 &amp; U14 Girls: 10 September - 3 December (half term break 29 October)
               </div><br/>
               <div class="jnr-table--heading">Spring term (10 weeks)</div>
               <div class="jnr-table--context">
-                U8 - U10: 13 January - 30 March (half term break 17 &amp; 24 February)<br />
-                U12 &amp; U14 Boys: 16 January - 26 March (half term break 20 February)<br />
-                U12 &amp; U14 Girls: 17 January - 27 March (half term break 21 February)
+                U8 - U10: 11 January - 29 March (half term break 15 &amp; 22 February)<br />
+                U12 &amp; U14 Boys: 14 January - 25 March (half term break 18 February)<br />
+                U12 &amp; U14 Girls: 14 January - 25 March (half term break 18 February)
               </div>
             </td>
           </tr>
@@ -102,19 +116,19 @@
             <td class="jnr-table--heading">Cost</td>
             <td class="jnr-table--details">
               <div class="jnr-table--heading">Season subscription</div>
-              <div class="jnr-table--context">£110 (£55 due September, £55 in January).</div>
-              <div class="jnr-table--context">25% discount for players starting after the October break (£27.50 due on joining; £55 in January).</div>
-              <div class="jnr-table--context">50% discount for players starting after the winter break (£55 due on joining).</div>
+              <div class="jnr-table--context">£120 (£60 due September, £60 in January).</div>
+              <div class="jnr-table--context">25% discount for players starting after the October break (£30 due on joining; £60 in January).</div>
+              <div class="jnr-table--context">50% discount for players starting after the winter break (£60 due on joining).</div>
             </td>
           </tr>
           <tr>
             <td class="jnr-table--heading">Kit</td>
             <td class="jnr-table--details">
-              <p>Each child who has completed their taster and paid subs receives a purple club
-              playing T-shirt. Navy shorts and purple socks are also available to purchase at
-              training. Other kit, including navy skorts as well as sweatshirts, hoodies, beanies
-              and rain jackets may be ordered via the
-              <a href="https://shop.cambridgesouthhockeyclub.co.uk/junior-kit" title="Club Shop" target="_blank">online club shop</a>.</p>
+              <p>Each child who has completed their taster and paid subs receives a free club
+              playing T-shirt! Navy shorts and purple socks are also available to purchase at
+              training. Other kit, including navy skorts as well as tops, hoodies and
+              rain jackets may be ordered from our kit supplier, Y1, via the
+              <a href="https://y1sport.com/collections/cambridge-south-hc" title="Club Shop" target="_blank">online club shop</a>.</p>
             </td>
           </tr>
         </tbody>
@@ -222,22 +236,12 @@
       {% document title="RESPECT - Code of Ethics and Behaviour" category="Juniors" %}
       {% document title="Junior handbook" category="Juniors" %}
     </div>
-    <div id="calendar" class="col-md-6 col-lg-4">
-      <span class="float-right">
-        <a href="https://calendar.google.com/calendar/ical/4oati7ee6231hb6gtajift5hvs%40group.calendar.google.com/public/basic.ics" title="Subscribe to the CSHC Juniors calendar" class="btn u-btn-primary">
-          <i class="far fa-calendar-plus g-mr-10"></i>Subscribe
-        </a>
-      </span>
-      <h3 class="g-mb-20">Juniors Calendar</h3>
-      <iframe src="https://calendar.google.com/calendar/embed?showTitle=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;showTz=0&amp;mode=AGENDA&amp;height=800&amp;wkst=2&amp;bgcolor=%23FFFFFF&amp;src=4oati7ee6231hb6gtajift5hvs%40group.calendar.google.com&amp;color=%23853104&amp;ctz=Europe%2FLondon"
-      style="border-width:0" width="100%" height="400" frameborder="0" scrolling="no"></iframe>
-    </div>
   </div>
 </section>
 
 {% static "img/members/ellie_raffan.jpg" as ellie_pic %}
-{% static "img/members/kea_haw.jpeg" as kea_pic %}
-{% static "img/members/bhav_virdi.jpg" as bhav_pic %}
+{% static "https://cshc-v3.s3.amazonaws.com/media/cache/84/d9/84d93c7378309aca3153f76d844e3d33.jpg" as nic_pic %}
+
 <section id="key_people" class="g-bg-secondary">
   <div class="container g-py-60">
     {% include 'blocks/_middle_heading.html' with title="Key People" %}
@@ -248,11 +252,7 @@
       </div>
 
       <div class="col-lg-3 col-sm-6 g-mb-30">
-        {% include 'club_info/_junior_contact.html' with thumbnail=bhav_pic name="Bhav Virdi" position="Juniors Coach" blurb="Bhav's been at CSHC since 2009 and has played for the M1s and M2s in his time at the club. He is a Level 2 Certificate England Hockey Coach. He coaches the juniors on Saturday mornings and has also coached our senior Ladies’ sides." %}
-      </div>
-
-      <div class="col-lg-3 col-sm-6 g-mb-30">
-        {% include 'club_info/_junior_contact.html' with thumbnail=kea_pic name="Kea Haw" email="welfare@cambridgesouthhockeyclub.co.uk" position="Juniors Welfare Officer" blurb="Kea has been a club member since 2020 and plays for the women's 4th XI as well as being a regular at 'Pay and Play' sessions and volunteering with junior coaching. For any welfare issues, concerns or queries regarding junior transition to senior hockey, Kea is always contactable (just click the envelope icon above!) and happy to chat." %}
+        {% include 'club_info/_junior_contact.html' with thumbnail=nic_pic name="Nicole Mills" email="welfare@cambridgesouthhockeyclub.co.uk" position="Juniors Welfare Officer" blurb="For any welfare issues, concerns or queries regarding junior transition to senior hockey, Nicole is always contactable (just click the envelope icon above!) and happy to chat." %}
       </div>
     </div>
   </div>

--- a/src/cshc/templates/club_info/kit.html
+++ b/src/cshc/templates/club_info/kit.html
@@ -37,8 +37,8 @@
 
 {% subheading "Ordering Kit" %}
 
-<p>In addition to the playing shirts, the club also offers a variety of official playing and training kit available to order on our <strong>
-  <a href="http://shop.cambridgesouthhockeyclub.co.uk/" target="_blank">online club shop</a></strong>.</p>
+<p>In addition to the playing shirts, the club also offers a variety of official playing and training kit available to order from our kit supplier 'Y1' via their <strong>
+ <a href="https://y1sport.com/collections/cambridge-south-hc" target="_blank">online shop</a></strong>.</p>
 <p>The playing kit items are all constructed out of high performance fabrics and are selected to complement your club shirt. The training 
   wear is smart and practical and incorporates the club crest and personalised embroidery and printing options.</p>
 

--- a/src/cshc/templates/core/stats.html
+++ b/src/cshc/templates/core/stats.html
@@ -50,7 +50,6 @@ Static landing page for stats - mainly a redirect from the old site.
 <div class="row">
   {% include 'core/_stats_item.html' with icon="fas fa-user" icon_color="pink" link=member_list_url title="Member Playing Records" description="Who's played the most matches for the club? Scored the most goals?" %}
   {% include 'core/_stats_item.html' with icon="fas fa-users" icon_color="cyan" link=playing_record_url title="Team Playing Records" description="Season summaries for each team." %}
-  {% include 'core/_stats_item.html' with icon="fas fa-crown" icon_color="primary" link=goal_king_url title="Goal King" description="Who's scored the most goals? And who's scoring the most per game?" %}
   {% include 'core/_stats_item.html' with icon="fas fa-chart-bar" icon_color="red" link=southerners_league_url title="Southerner's League" description="How do the various Cambridge South teams stack up against each other?" %}
   {% include 'core/_stats_item.html' with icon="fas fa-table" icon_color="orange" link=opposition_club_list_url title="Rivals" description="Comprehensive stats on Cambridge South's performance against each rival club." %}
   {% include 'core/_stats_item.html' with icon="fas fa-car" icon_color="blue" link=accidental_tourist_url title="Accidental Tourist" description="Who's travelled the furthest for the cause? And who is a 'Reluctant Traveller'?" %}

--- a/src/cshc/templates/index.html
+++ b/src/cshc/templates/index.html
@@ -170,17 +170,6 @@
   </div>
 </section>
 
-<section id="training" class="g-bg-gray-light-v5">
-  <div class="container text-center g-py-60">
-    {% include 'blocks/_middle_heading.html' with title="Upcoming Training Sessions" %}
-    <div class="row justify-content-center">
-      <div class="col-lg-9">
-        {% include 'training/_next_training.html' %}
-      </div>
-    </div>
-  </div>
-</section>
-
 <section id="news" class="container g-py-60">
   {% include 'blocks/_middle_heading.html' with title="Latest News" %}
   {% get_recent_entries 3 'core/_recent_articles.html' %}

--- a/src/cshc/templates/training/masters.html
+++ b/src/cshc/templates/training/masters.html
@@ -38,7 +38,7 @@
 <section class="container g-mt-20 g-mt-40--md g-mb-40">
   {% render_breadcrumbs %}
 
-  <p class="g-mb-20 g-mb-40--md g-font-size-16 g-font-size-24--md text-center">Cambridge South runs informal women’s over-30s hockey weekly from March to September on Mondays, 8pm to 9pm, at
+  <p class="g-mb-20 g-mb-40--md g-font-size-16 g-font-size-24--md text-center">Cambridge South runs informal women’s over-30s hockey fortnightly from September to March on Thursdays, 7pm to 8pm, at
   <a href="{{ long_road_url }}">Long Road Sixth Form College</a>.</p>
 
   <p class="lead">The sessions consist of a small-sided knock-around casual game on a half pitch. There are no umpires or keeping score, just a chance to run around with a hockey stick for some fun and exercise in a friendly, non-competitive session. Players don't have to be club members and new people are very welcome, whether complete beginners or coming back to the sport after a break. Spare sticks are available to borrow for players without their own, all you need is some comfortable sportswear. A mouthguard and shin pads are recommended.
@@ -51,7 +51,7 @@
       <div class="col-md-9 align-self-center">
         <h3 class="h4">If you'd like to come along and give it a go, we'd love to hear from you</h3>
         <p class="lead g-mb-20 g-mb-0--md">Players should pre-book for a session via the <em>Spond</em> app or web portal. If you’re new to the club, contact the Club Secretary, {% clubinfo_email 'SecretaryEmail' sec_name %}, to
-          be registered with us on Spond. The cost is £4 or £2 if unwaged, payable on the night via contactless payment.</p>
+          be registered with us on Spond. The cost is £5 or £2.50 if unwaged, payable on the night via contactless payment.</p>
       </div>
 
       <div class="col-md-3 align-self-center text-md-right">

--- a/src/cshc/templates/training/trainingsession_list.html
+++ b/src/cshc/templates/training/trainingsession_list.html
@@ -57,15 +57,15 @@
         <h4 class="h4 g-color-black g-mb-15">Ladies' Squads</h4>
         <div class="g-mb-10"><a href="{{ long_road_url }}" title="Venue details">Long Road Sixth Form College</a></div>
         <div class="g-font-style-italic  g-mb-20">
-          1st &amp; 2nd XIs - Tuesdays, 7:30pm - 9:30pm*<br/>
-          3rd &amp; 4th XIs - Thursdays, 7pm - 8:30pm or 8:30pm - 10pm**<br/>
-          5th &amp; 6th XIs - Thursdays, 7pm - 8:30pm or 8:30pm - 10pm**
+          1st &amp; 2nd XIs - Tuesdays, 7:30pm - 9:30pm<br/>
+          5th &amp; 6th XIs - Mondays, 7:30pm - 9pm
           <div class="g-font-size-14 g-pt-10 g-color-gray-dark-v5">Please arrive 15 minutes early to warm up</div>
         </div>
-        <p class="lead g-color-gray-dark-v5 g-font-weight-600">The Ladies' 1s and Ladies' 2s squads train on Tuesday nights, while the remaining teams - including
-          players new or returning to hockey - train on Thursday evenings.</p>
-        <p>* 9pm - 9:30pm for the Ladies' 1s and 2s has a surcharge.</p>
-        <p>** Training times alternate weekly.</p>
+        <div class="g-mb-10"><a href="{{ st_marys_url }}" title="Venue details">St Mary's & Homerton Sports Ground</a></div>
+        <div class="g-font-style-italic  g-mb-20">
+          3rd &amp; 4th XIs - Thursdays, 7:30pm - 9pm<br/>
+          <div class="g-font-size-14 g-pt-10 g-color-gray-dark-v5">Please arrive 15 minutes early to warm up</div>
+        </div>
       </div>
     </div>
     <div class="col-md-6 px-0">
@@ -83,20 +83,15 @@
           <h4 class="h4 g-color-black g-mb-15">Men's Squads</h4>
           <div class="g-mb-10"><a href="{{ long_road_url }}" title="Venue details">Long Road Sixth Form College</a></div>
           <div class="g-font-style-italic  g-mb-20">
-            1st &amp; 2nd XIs - Wednesdays, 7:30pm - 9:30pm*<br/>
-            3rd &amp; 4th XIs - Mondays, 8:30pm - 10pm
+            1st &amp; 2nd XIs - Wednesdays, 7:30pm - 9:30pm<br/>
+            3rd &amp; 4th XIs - Thursdays, 8pm - 9:30pm
             <div class="g-font-size-14 g-pt-10 g-color-gray-dark-v5">Please arrive 15 minutes early to warm up</div>
           </div>
           <div class="g-mb-10"><a href="{{ st_marys_url }}" title="Venue details">St Mary's & Homerton Sports Ground</a></div>
           <div class="g-font-style-italic  g-mb-20">
-            5th &amp; 6th XIs - Tuesdays, 7:30pm - 9pm
+            5th, 6th &amp; 7th XIs - Tuesdays, 7:30pm - 9pm
             <div class="g-font-size-14 g-pt-10 g-color-gray-dark-v5">Please arrive 15 minutes early to warm up</div>
           </div>
-          <p class="lead g-color-gray-dark-v5 g-font-weight-600">The Men's 1s and 2s squads train on Wednesday nights while the remaining teams train on other nights.
-          </p>
-          <p>
-            * 9pm - 9:30pm for the Men's 1s and 2s has a surcharge.
-          </p>
         </div>
       </div>
     </div>
@@ -154,40 +149,9 @@
     </p>
     <p class="lead">
       To play, pre-book for a session via the <em>Spond</em> app or web portal. If you’re new to the club, contact {% clubinfo_email 'SecretaryEmail' sec_name %}, to
-      be registered with us on Spond. The cost is &pound;4 per session or &pound;2 for students and the unwaged, payable on the night via contactless payment.
+      be registered with us on Spond. The cost is &pound;5 per session or &pound;2.50 for students and the unwaged, payable on the night via contactless payment.
       If you're new to the club, your first session is free!
     </p>
-  </div>
-</section>
-
-<section>
-  <div class="container g-mb-40">
-    <div class="row">
-      <div class="col-12 col-lg-8 g-mb-20">
-        <div class="card g-brd-primary rounded-0">
-          <h3 class="card-header g-bg-primary g-brd-transparent g-color-white g-font-size-16 rounded-0 mb-0">
-            Next Training Sessions
-          </h3>
-          {% include 'training/_next_training.html' %}
-        </div>
-      </div>
-      <div class="col-12 col-lg-4 g-mb-20">
-        <div class="g-bg-gray-light-v5 g-pa-30 text-center">
-          <h4>Make it easy for yourself!</h4>
-          <p class="lead g-py-20">
-            All Cambridge South training sessions are available as a <strong>.ics calendar feed</strong> that you can link into your own
-            calendar client (Outlook, iPhone etc).
-          </p>
-          <a class="btn btn-md u-btn-outline-primary g-brd-2 rounded-0" href="{{ calendar }}#feeds"><i class="far fa-calendar-plus g-mr-5"></i>Subscribe</a>
-        </div>
-      </div>
-    </div>
-    {% if perms.training.add_trainingsession %}
-      <div class="g-py-20">
-        <a href="{{ create_training_session }}" title="Add training sessions in bulk" class="btn u-btn-outline-primary">Add training sessions</a>
-      </div>
-    {% endif %}
-    {% model_admin_links 'training' 'trainingsession' %}
   </div>
 </section>
 

--- a/src/cshc/views.py
+++ b/src/cshc/views.py
@@ -33,7 +33,6 @@ class HomeView(TemplateView):
 
         # Sub-navigation elements
         context['sub_nav_items'] = [
-            {'id': 'training', 'label': 'Next Training'},
             {'id': 'news', 'label': 'Latest News'},
             {'id': 'comments', 'label': 'Recent Comments'},
             {'id': 'tweets', 'label': 'Tweets'},


### PR DESCRIPTION

Updates here are as per the [RAB] descriptions below (from the email chain).
 ---

From: Eleanor Raffan <eraffan@fastmail.fm> 
Sent: 10 September 2024 12:52
To: Rob Barton <home@robbarton.com>; Neil Sneade <njs1005@cantab.net>
Cc: Kern Matt <matt.kern@undue.org>; Graham McCulloch <graham@grahammcculloch.co.uk>; Jessica Kitt <jessica_surman@yahoo.com>; Georgie Hurford <georgiehurford@hotmail.com>; Louisa Warburton <louisamwarburton@gmail.com>
Subject: Re: CSHC web page updates for 2024/25

Hi Matt, Hi grhaham et al, cc junior age group leads in case anyone has any urgent requests.

Sorry for slow response - In Oz and have had to fill in gaps. 

1) To the juniors home page where there is some basic text already, please could you add this paragraph above the paragraph 'we offer 3 free...':

Each age group play matches at different levels to make sure there is competitive hockey for all our players. Development tournaments are very friendly occasions that enable newer/ less experienced players to have matches against similarly skilled opposition.  Stronger players from U10 upwards also play against local clubs at a higher level. This gives our players excellent opportunities to develop their skills. Note that our fixtures are almost always on Sundays and are additional to training.

[RAB] Done.
 
2) Lower down under key people: 
•	Please take Bhav and all mention of junior coach off the website. (Bhav has left, we have too many super coaches to mention).
•	Please put Nicole Mills in as welfare officer. You could get her profile pic from spond or I will forward if I she responds to my message.
[RAB] Maybe done.  All the text is done but I’ve forgotten how to upload an img static file.  So instead I’m gambling on the profile picture URL working. You might need to fix this.  Should look like the image below…
3) And please change to this version of the junior handbook - attached. There's an old word doc already there.

[RAB] Done and live (though I might tweak the PDF if I get a new one from Ellie).

 

I hope that's all ok - really appreciate this all. 

Thank you!
Ellie 
-- 
  Eleanor Raffan


On Fri, 6 Sep 2024, at 9:58 AM, Rob Barton wrote:

See below (optionally) for a small rant**… 😊

More seriously, we can probably make the page disappear without destroying the stats and site in a way which would be easy to put back if the club pushes back to the committee in the future.  Please record my “vote” to do this!  There are some related pages to be considered too: presumably Southerners and Accidental Tourist are innocent enough to stay.  And we’ll keep the history I assume.  But what about The Naughty Step … should that also be hidden?

I’ll wait for Ellie before pushing any pull request but can start to work on the changes this weekend and early next week.


Cheers!

Rob

 
P.S.
I have performed the recent player link request for James M.
 
** Actually, why not go one step further: simply dismantle the goals!  That way it avoids all frustration if your teammate scores instead of you, plus you never get the disappointment of conceding!  Everyone wins!  We could start tracking square and backward passes instead – snowflake to snowflake – and there could be a new award for most lateral ball distance in a season.



______________
[home@robbarton.com](mailto:home@robbarton.com)
07903274823
[www.robbarton.com](http://www.robbarton.com/)
    
 
From: Neil Sneade <[njs1005@cantab.net](mailto:njs1005@cantab.net)> 
Sent: 05 September 2024 10:29
To: [home@robbarton.com](mailto:home@robbarton.com)
Cc: Matt Kern <[matt.kern@undue.org](mailto:matt.kern@undue.org)>; Eleanor Raffan <[eraffan@fastmail.fm](mailto:eraffan@fastmail.fm)>; Graham McCulloch <[graham@grahammcculloch.co.uk](mailto:graham@grahammcculloch.co.uk)>
Subject: Re: CSHC web page updates for 2024/25
 
The scoring stats aren't being removed, just the table and awards. The motion wasn’t raised by me, but it was surprisingly well-supported at the committee meeting; apparently the teams do find it creates issues in some cases. In any case, the motion was proposed and passed so it’s an official motion of the club now, I’m afraid. You could ask the committee to reconsider at the next meeting but for the moment the decision has been made to hide the page.



On 5 Sep 2024, at 10:09, Rob Barton <[home@robbarton.com](mailto:home@robbarton.com)> wrote:

Hi all,
 
Thanks for the details, which all seem largely sensible.
 
Ellie: If you could let us have the final changes you want to juniors this week (before Friday 6pm) that would be useful.
 
Matt: Yes, let’s split the load.  I’ll have a first go over the next few days (maybe 1 week) and create a PR with the static changes requested.  As usually, I’ll need your help validating but I should be able to take most of the heavy lifting here.
 
All: We simply cannot remove Goal King or Southerners League!  That’s part of South’s historical fabric!  Agreed that the awards might not be necessary though so playing it down is a good thing…  One of the best things about our site – the best hockey site out there – is all the stats and goals, clean sheets and appearances; they are a key part of making the site what it is.  When did Cambridge South become “un-fun”?  We really shouldn’t do this … if anything we should add a Clean Sheets table, most MoM/LoM, etc… as counterbalance in the future.
 
Cheers!
 
Rob
 
______________
[home@robbarton.com](mailto:home@robbarton.com)
07903274823
[www.robbarton.com](http://www.robbarton.com/)
    
 
From: Neil Sneade <[njs1005@cantab.net](mailto:njs1005@cantab.net)> 
Sent: 04 September 2024 13:34
To: Matt Kern <[matt.kern@undue.org](mailto:matt.kern@undue.org)>; Rob Barton <[home@robbarton.com](mailto:home@robbarton.com)>
Cc: Eleanor Raffan <[eraffan@fastmail.fm](mailto:eraffan@fastmail.fm)>
Subject: Re: CSHC web page updates for 2024/25
 
I think Ellie may also want some further updates to the Juniors page. I’ve cc’ed her so she can let you know what these are.




On 4 Sep 2024, at 12:52, Neil Sneade <[njs1005@cantab.net](mailto:njs1005@cantab.net)> wrote:
 
Thanks, Matt. There’s one other update I forgot: the Juniors page!
 
https://cambridgesouthhockeyclub.co.uk/juniors/
Update the details table to be:
 
Location [Long Road Sixth Form College](https://cambridgesouthhockeyclub.co.uk/venues/long-road/)
 
Time        U8 - U10 (years 2 - 5): Saturdays, 8:45am - 10am
                   U12 Girls (years 6 & 7) and U14 Girls (years 8 & 9): Tuesdays, 6pm - 7:30pm
 
Location [St Mary’s & Homerton Sports Ground](https://cambridgesouthhockeyclub.co.uk/venues/st-marys/)
 
Time        U12 Boys (years 6 & 7) and U14 Boys (years 8 & 9): Tuesdays, 6pm - 7:30pm
 
Dates       2024/25
 
Autumn term (12 weeks)
U8 - U10: 7 September - 7 December (half term break 26 October & 2 November)
U12 & U14 Boys: 10 September - 3 December (half term break 29 October)
U12 & U14 Girls: 10 September - 3 December (half term break 29 October)
 
Spring term (10 weeks)
U8 - U10: 11 January - 29 March (half term break 15 & 22 February)
U12 & U14 Boys: 14 January - 25 March (half term break 18 February)
U12 & U14 Girls: 14 January - 25 March (half term break 18 February)
 
Cost          Season subscription
£120 (£60 due September, £60 in January).
25% discount for players starting after the October break (£30 due on joining; £60 in January).
50% discount for players starting after the winter break (£60 due on joining).
 
Kit            
Each child who has completed their taster and paid subs receives a purple club playing T-shirt. Navy shorts and purple socks are also available to purchase at training. Other kit, including navy skorts as well as tops, hoodies and rain jackets may be ordered from our kit supplier, Y1, via the [online club shop](https://y1sport.com/collections/cambridge-south-hc).

 [RAB] All done.

Again, I would also remove the Juniors’ Google calendar box as the season dates are given above, and individual sessions are in Spond.

[RAB] Done.  Please check the rendering here, though it looked OK in chrome’s dev tools at all width breakpoints.  I think I’ve removed the submenu link too but cannot test that.  I kept the template HTML around though.

[RAB] At this point I created a commit on GH.  Read on… 
 
Neil




On 4 Sep 2024, at 12:23, Matt Kern <[matt.kern@undue.org](mailto:matt.kern@undue.org)> wrote:
 
Thanks for this, Neil.
 
How much of this do you think you can take on Rob?  I'll do the rest.
 
We could maybe look at integrating with Spond to pull out the training sessions and post them on our website.  The alternative would be to create dummy events based on the schedule, but this could catch people out when times and days are swapped around.
 
Matt
 
On Wed, 4 Sept 2024 at 11:52, Neil Sneade <[njs1005@cantab.net](mailto:njs1005@cantab.net)> wrote:
Hi both, here are the updates needed to the details on the club web site for the new season:
 
https://cambridgesouthhockeyclub.co.uk/
Can the ‘Next Training’ link just beneath the results and fixtures tables be re-directed to point to https://cambridgesouthhockeyclub.co.uk/training/ and the ‘Upcoming Training Sessions’ section further down removed, as we don’t enter training sessions into the web site as Spond is now the single source of truth.
[RAB]  Done.  Well attempted, somewhat blindly, needs verification.  I didn’t furtle with the background colours but am not sure that matters too much.
 
https://cambridgesouthhockeyclub.co.uk/training/
Ladies’ Squads details should now read:
 
Long Road Sixth Form College
 
1st & 2nd XIs - Tuesdays, 7:30pm - 9:30pm
5th & 6th XIs - Mondays, 7.30pm - 9pm
 
St Mary’s & Homerton Sports Ground
 
3rd & 4th XIs - Thursdays, 7.30pm - 9pm
 
Please arrive 15 minutes early to warm up
 
Men’s Squads details should now read:
 
Long Road Sixth Form College
 
1st & 2nd XIs - Wednesdays, 7:30pm - 9:30pm
3rd & 4th XIs - Thursdays, 8pm - 9.30pm
 
St Mary's & Homerton Sports Ground
 
5th, 6th & 7th XIs - Tuesdays, 7:30pm - 9pm
 
Please arrive 15 minutes early to warm up
 
The ‘1st and 2nd Team Training’ section can be deleted.

[RAB]  Done, please check. 
 
In the ‘Pay & Play’ section, the cost should be updated to "£5 per session or £2.50 for students and the unwaged”.

[RAB]  Done.  
 
Delete the ’Next Training Sessions’ box and link to the Google calendar feed. Nowadays everything is in Spond, and Spond can be linked to your calendar so the old feed is redundant. Likewise delete the ‘Add training sessions’ link.

[RAB]  Done.  And removed the admin edit option as it was part of the whole (removed) section.
 
https://cambridgesouthhockeyclub.co.uk/about/directions/
This should be changed to say "We train and play our home matches at Long Road Sixth Form College and at St Mary’s School & Homerton College Sports Ground, in south Cambridge.” and the Google map updated accordingly.

[RAB]  Text updated.  Didn’t touch the map, not sure we should TBH.
 
https://cambridgesouthhockeyclub.co.uk/about/kit/
Under ‘Ordering Kit’, the link to our online club shop ought to be updated to point to the Y1 shop at https://y1sport.com/collections/cambridge-south-hc

[RAB]  Done.
 
https://cambridgesouthhockeyclub.co.uk/training/masters/
The first paragraph should be change to read:
 
Cambridge South runs informal women’s over-30s hockey fortnightly from September to March on Thursdays, 7pm to 8pm, at Long Road Sixth Form College.
 
The cost should also be updated to be £5 or £2.50 unwaged.

[RAB]  Done.
 
https://cambridgesouthhockeyclub.co.uk/about/committee/
I’ve added captains for this season in the admin interface at https://cambridgesouthhockeyclub.co.uk/admin/teams/teamcaptaincy/?season__id__exact=55 but for some reason they’re not showing on this page! I haven’t added committee members for 2024/25 yet but will do.

[RAB]  That’s odd.  Not sure what’s going on here.  Perhaps a season mismatch on the backend for that page?  The Admin changes look sensible.
 
https://cambridgesouthhockeyclub.co.uk/calendar/
I would delete this page, given its replacement by Spond. For fixture details people will look at the front page or individual team pages.

[RAB]  I slightly disagree!  This still syncs with the current fixtures and I know a few people use the Google calendar.  Maybe there isn’t the need for this actual page, but let’s keep it given the fixtures are still current.
 
https://cambridgesouthhockeyclub.co.uk/matches/goal-king/
It was resolved at the last committee meeting that the Goal King and Goal Queen will be retired as awards at the Annual Dinner, and this page should be hidden, as it has encouraged negative behaviours and selfish play from some people. All players will still be able to see their personal scoring stats on their playing profile page, they just won’t be presented in a ranking table.

[RAB]  Reluctantly, with a heavy heart, removed all links as discussed.

 
--
Matt Kern