### PR TITLE
Align seasons to run from 01-Jul to 30-Jun

### DIFF
--- a/src/competitions/models/season.py
+++ b/src/competitions/models/season.py
@@ -9,10 +9,11 @@ from django.db.models.query import QuerySet
 from django.core.exceptions import ValidationError
 
 # Define the default season start/end dates
-SEASON_START_MONTH = 9  # Sept
-SEASON_END_MONTH = 8    # Aug
+# To aid preparation and August friendlies, seasons un from 01-Jul to 30-Jun.
+SEASON_START_MONTH = 7  # July
+SEASON_END_MONTH = 6    # June
 SEASON_START_DAY = 1
-SEASON_END_DAY = 31
+SEASON_END_DAY = 30
 
 LOG = logging.getLogger(__name__)
 
@@ -108,7 +109,7 @@ class Season(models.Model):
         """ Utility method to create the current season."""
         current = Season()
         dtnow = datetime.now()
-        if dtnow.month >= 9:
+        if dtnow.month >= SEASON_START_MONTH:
             start_year = dtnow.year
         else:
             start_year = dtnow.year - 1


### PR DESCRIPTION
This tweak aligns seasons to run between 01-Jul and 30-Jun each year.  Other parts of the website assume this, but the code which creates new seasons (should one need creating) used to use 01-Sep to 31-Aug.

This PR updates the Season.create_current_season() method to use dates between 01-Jul and 30-Jun.

Testing with now (05-Jul-'25) -> 2025-2026
Testing with two months ago (05-May-'25) -> 2024-2025

@mwk20 - please code review and test against the real DB.