### PR TITLE
Update mgmt cmds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,10 @@ src/media/*
 docs/_build/*
 
 # Production database dump file
-prod_dump.sql
-# Elastic Beanstalk Files
-.elasticbeanstalk/*
-!.elasticbeanstalk/*.cfg.yml
-!.elasticbeanstalk/*.global.yml
+prod_dump.sql
+*.dump
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/src/core/management/commands/import_db_dump.py
+++ b/src/core/management/commands/import_db_dump.py
@@ -1,0 +1,88 @@
+"""
+Management command that copies the latest database dump from the production
+Amazon S3 bucket to the local file system and converts it to SQLite3 format
+for development purposes.
+"""
+
+import os
+import subprocess
+import traceback
+import boto3
+from django.core.management.base import BaseCommand
+
+PROD_BUCKET_NAME = 'cshc-v3'
+
+class Command(BaseCommand):
+
+    def __init__(self):
+        super(Command, self).__init__()
+
+    def handle(self, *args, **options):
+        try:
+            s3 = boto3.resource('s3')
+            prod_bucket = s3.Bucket(PROD_BUCKET_NAME)
+            dump_objects = []
+
+            # Find all .dump files in the root of the bucket
+            for obj_summary in prod_bucket.objects.filter(Prefix='default-cambridgesouthhockeyclub.co.uk-'):
+                # Only include files that end with .dump and are in the root (no '/' in key except potential trailing)
+                if obj_summary.key.endswith('.dump') and obj_summary.key.count('/') == 0:
+                    dump_objects.append(obj_summary)
+
+            if not dump_objects:
+                print('No dump files found')
+                return
+
+            # Sort by last_modified to get the latest dump
+            latest_dump = sorted(dump_objects, key=lambda x: x.last_modified, reverse=True)[0]
+            print('Latest dump file: {}'.format(latest_dump.key))
+
+            # Download the latest dump file
+            local_filename = latest_dump.key
+                       
+            if os.path.isfile(local_filename):
+                print('File already exists locally: {}'.format(local_filename))
+            else:
+                print('Downloading {} ...'.format(latest_dump.key))
+                prod_bucket.download_file(latest_dump.key, local_filename)
+                print('Download complete.')
+
+            # Use mysql2sqlite to convert the dump to SQLite format
+            print('Converting dump file to SQLite3 format (this takes a while) ...')
+            
+            try:
+                # Run mysql2sqlite and pipe to sqlite3
+                with open('db.sqlite3', 'w') as db_file:
+                    mysql2sqlite = subprocess.Popen(
+                        ['mysql2sqlite', local_filename],
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE
+                    )
+                    sqlite3 = subprocess.Popen(
+                        ['sqlite3', 'db.sqlite3'],
+                        stdin=mysql2sqlite.stdout,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE
+                    )
+                    mysql2sqlite.stdout.close()
+                    
+                    stdout, stderr = sqlite3.communicate()
+                    
+                    if sqlite3.returncode != 0:
+                        print('Error converting database:')
+                        print(stderr.decode())
+                    else:
+                        print('Conversion complete: db.sqlite3')
+                        
+            except FileNotFoundError:
+                print('Error: mysql2sqlite command not found. Please install it first.')
+            except Exception as e:
+                print('Error during conversion: {}'.format(str(e)))
+
+            # Remove the local dump file after successful conversion
+            if os.path.isfile(local_filename):
+                os.remove(local_filename)
+                print('Removed dump file: {}'.format(local_filename))
+
+        except:
+            traceback.print_exc()

--- a/src/core/management/commands/media_copy.py
+++ b/src/core/management/commands/media_copy.py
@@ -50,26 +50,34 @@ class Command(BaseCommand):
                     'Key': obj_summary.key,
                 }
 
+                skip_staging = False
                 if staging_bucket:
                     ts = new_objects.get((obj_summary.key, obj_summary.size))
                     if ts is not None and ts >= obj_summary.last_modified:
-                        print('Skipping {}'.format(obj_summary.key))
-                        continue
+                        print('Skipping staging copy for {}'.format(obj_summary.key))
+                        skip_staging = True
 
-                print('Copying {}'.format(obj_summary.key))
+                if not skip_staging:
+                    print('Copying {}'.format(obj_summary.key))
 
-                if staging_bucket:
-                    staging_bucket.copy(
-                        copy_source,
-                        obj_summary.key,
-                        ExtraArgs=extra_args,
-                    )
+                    if staging_bucket:
+                        staging_bucket.copy(
+                            copy_source,
+                            obj_summary.key,
+                            ExtraArgs=extra_args,
+                        )
 
                 if options['local'] and not obj_summary.key.endswith('/'):
-                    if not os.path.isfile(obj_summary.key):
-                        os.makedirs(os.path.dirname(
-                            obj_summary.key), exist_ok=True)
+                    dir_name = os.path.dirname(obj_summary.key).lower()
+                    file_name = os.path.basename(obj_summary.key)
+                    local_path = os.path.join(dir_name, file_name)
+                    
+                    if os.path.isfile(local_path):
+                        print('Skipping local copy for {} (already exists)'.format(obj_summary.key))
+                    else:
+                        print('Copying locally {}'.format(obj_summary.key))
+                        os.makedirs(dir_name, exist_ok=True)
                         prod_bucket.download_file(
-                            obj_summary.key, obj_summary.key)
+                            obj_summary.key, local_path)
         except:
             traceback.print_exc()


### PR DESCRIPTION
A few changes to improve the process to set up a local development environment:
* Updates the `media_copy` Django management command so that media files are copied locally even if they already exist in the staging bucket when the `--local` option is used. Previously, files which were already in staging were skipped completely.
* Adds a new Django management command `import_db_dump` which will copy the most recent MySQL database from the prod S3 bucket locally and convert it to SQLite3 for local development.
* Adds `*.dump` to `.gitignore` and normalizes the line endings (removing some Windows CRLF endings)