### PR TITLE
Don't try to create thumbnails of missing profile pics

### DIFF
--- a/src/cshc/templates/comments/comment.html
+++ b/src/cshc/templates/comments/comment.html
@@ -24,7 +24,7 @@
 
 {% if preview %}<h3>{% trans "Preview of your comment" %}</h3>{% endif %}
 <div {% if preview %}id="comment-preview" {% else %}id="c{{ comment.id }}" {% endif %} class="media g-mb-15">
-  {% if comment.user and comment.user.has_member %}
+  {% if comment.user and comment.user.has_member and comment.user.member.profile_pic %}
     {% thumbnail comment.user.member.profile_pic "50x50" crop="center" as im %}
       <img class="d-flex g-width-50 g-height-50 rounded-circle g-mt-3 g-mr-15" src="{{ im.url }}">
     {% empty %}

--- a/src/cshc/templates/comments/form.html
+++ b/src/cshc/templates/comments/form.html
@@ -22,7 +22,7 @@
 
 {% else %}
   <div class="media g-mb-30">
-    {% if user.has_member %}
+    {% if user.has_member and user.member.profile_pic %}
       {% thumbnail user.member.profile_pic "50x50" crop="center" as im %}
         <img class="d-flex g-width-50 g-height-50 rounded-circle g-mt-3 g-mr-15" src="{{ im.url }}">
       {% empty %}

--- a/src/cshc/templates/members/_profile_pic_thumbnail.html
+++ b/src/cshc/templates/members/_profile_pic_thumbnail.html
@@ -10,12 +10,19 @@ Expected context:
 {% load thumbnail from sorl_thumbnail %}
 
 <div class="{{ class }} g-pos-rel">
-  {% thumbnail member.profile_pic size crop="center" as im %}
-    <img class="u-shadow-v29 w-100 rounded-circle" src="{{ im.url }}">
-  {% empty %}
-    <div class=" g-pos-rel w-100 u-shadow-v29 rounded-circle shirt-wrapper" style="width: {{ width }};">
-      <img class="w-100" src="{{ fallbackImage }}">
-      <div class="g-pos-abs text-center shirt-number">{{ member.shirt_number|default:"" }}</div>
-    </div>
-  {% endthumbnail %}
+  {% if member.profile_pic %}
+    {% thumbnail member.profile_pic size crop="center" as im %}
+      <img class="u-shadow-v29 w-100 rounded-circle" src="{{ im.url }}">
+    {% empty %}
+      <div class=" g-pos-rel w-100 u-shadow-v29 rounded-circle shirt-wrapper" style="width: {{ width }};">
+        <img class="w-100" src="{{ fallbackImage }}">
+        <div class="g-pos-abs text-center shirt-number">{{ member.shirt_number|default:"" }}</div>
+      </div>
+    {% endthumbnail %}
+  {% else %}
+      <div class=" g-pos-rel w-100 u-shadow-v29 rounded-circle shirt-wrapper" style="width: {{ width }};">
+        <img class="w-100" src="{{ fallbackImage }}">
+        <div class="g-pos-abs text-center shirt-number">{{ member.shirt_number|default:"" }}</div>
+      </div>
+  {% endif %}
 </div>


### PR DESCRIPTION
The thumbnail generator throws an error when the source image isn't found, which happens whenever someone doesn't have a profile pic, so we should just skip generating thumbnails when there is no profile pic.

Changes three templates where profile pics are used:
- `comment.html` - shows comments e.g., at the bottom of the main page
- `form.html` - used when submitting comments
- `_profile_pic_thumbnail.html` (which is used in the squad list on match reports)