### PR TITLE
Fix get_thumbnail_url NaN exception

### DIFF
--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -50,7 +50,7 @@ def get_thumbnail_url(image_field, size, crop=None, cropping_field=None):
         kwargs['crop'] = crop
     if cropping_field:
         cropbox = str(cropping_field)
-        if cropbox != '0x0':
+        if cropbox and cropbox != '0x0' and 'NaN' not in cropbox:
             kwargs['cropbox'] = cropbox
     if not image_field or not image_field.url:
         return None


### PR DESCRIPTION
An exception is thrown if the thumbnail cropper gets `NaN` as the `cropbox`, which seems to happen for some match team views (e.g., Men's 3s, 2018-2019).

I didn't try to fix the frontend to stop the `NaN` values getting injected, but have stopped them being processed and raising errors in the backend.