### PR TITLE
Changes to Member Search

### DIFF
--- a/src/frontend/js/components/common/Paged.jsx
+++ b/src/frontend/js/components/common/Paged.jsx
@@ -7,6 +7,9 @@ const urlPropsQueryConfig = {
   pageSize: {
     type: UrlQueryParamTypes.number,
   },
+  sorted: {
+      type: UrlQueryParamTypes.json,
+    },
 };
 
 export default urlPropsQueryConfig;

--- a/src/frontend/js/components/members/MemberList/MemberFilterSet/index.jsx
+++ b/src/frontend/js/components/members/MemberList/MemberFilterSet/index.jsx
@@ -37,13 +37,12 @@ export const urlPropsQueryConfig = {
 
 const MemberFilterSet = ({ teams, seasons }) => {
   const teamOptions = teams.map(team => ({ value: team.slug, label: team.long_name }));
-  teamOptions.unshift({ value: NoFilter, label: 'All' });
   const genderOptions = [
-    { value: NoFilter, label: 'Men & Ladies' },
     { value: 'Male', label: 'Men' },
     { value: 'Female', label: 'Ladies' },
   ];
   const seasonOptions = seasons.map(season => ({ value: season, label: season }));
+  seasonOptions.unshift({ value: NoFilter, label: 'All' });
   const positionOptions = [
     { value: Position.Goalkeeper, label: Position.Goalkeeper },
     { value: Position.Defence, label: Position.Defence },
@@ -89,6 +88,14 @@ const MemberFilterSet = ({ teams, seasons }) => {
           label="Coaches"
         />
       </FilterGroup>
+      <FilterGroup title="Gender">
+        <SelectFilter
+          filterName={FilterName.Gender}
+          options={genderOptions}
+          urlQueryConfig={urlPropsQueryConfig[FilterName.Gender]}
+          stacked
+        />
+      </FilterGroup>
       <FilterGroup title="Season">
         <SelectFilter
           filterName={FilterName.Season}
@@ -97,20 +104,12 @@ const MemberFilterSet = ({ teams, seasons }) => {
           stacked
         />
       </FilterGroup>
-      <FilterGroup title="Gender">
-        <OptionListFilter
-          filterName={FilterName.Gender}
-          urlQueryConfig={urlPropsQueryConfig[FilterName.Gender]}
-          defaultValue={NoFilter}
-          options={genderOptions}
-        />
-      </FilterGroup>
-      <FilterGroup title="Squad">
-        <OptionListFilter
+      <FilterGroup title="Team">
+        <SelectFilter
           filterName={FilterName.Team}
-          urlQueryConfig={urlPropsQueryConfig[FilterName.Team]}
-          defaultValue={NoFilter}
           options={teamOptions}
+          urlQueryConfig={urlPropsQueryConfig[FilterName.Team]}
+          stacked
         />
       </FilterGroup>
       <FilterGroup title="Position">

--- a/src/frontend/js/components/members/MemberList/MemberFilterSet/index.jsx
+++ b/src/frontend/js/components/members/MemberList/MemberFilterSet/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { UrlQueryParamTypes, pushUrlQuery } from 'react-url-query';
 import { FilterName, Position, NoFilter } from 'util/constants';
 import { FilterGroup } from 'components/filters';
-import { BooleanFilter, TextFilter, OptionListFilter } from 'components/filters/UrlFilter';
+import { BooleanFilter, TextFilter, OptionListFilter, SelectFilter } from 'components/filters/UrlFilter';
 
 export const urlPropsQueryConfig = {
   [FilterName.TextSearch]: {
@@ -27,12 +27,15 @@ export const urlPropsQueryConfig = {
   [FilterName.Team]: {
     type: UrlQueryParamTypes.string,
   },
+  [FilterName.Season]: {
+    type: UrlQueryParamTypes.string,
+  },
   [FilterName.Position]: {
     type: UrlQueryParamTypes.array,
   },
 };
 
-const MemberFilterSet = ({ teams }) => {
+const MemberFilterSet = ({ teams, seasons }) => {
   const teamOptions = teams.map(team => ({ value: team.slug, label: team.long_name }));
   teamOptions.unshift({ value: NoFilter, label: 'All' });
   const genderOptions = [
@@ -40,6 +43,7 @@ const MemberFilterSet = ({ teams }) => {
     { value: 'Male', label: 'Men' },
     { value: 'Female', label: 'Ladies' },
   ];
+  const seasonOptions = seasons.map(season => ({ value: season, label: season }));
   const positionOptions = [
     { value: Position.Goalkeeper, label: Position.Goalkeeper },
     { value: Position.Defence, label: Position.Defence },
@@ -85,6 +89,14 @@ const MemberFilterSet = ({ teams }) => {
           label="Coaches"
         />
       </FilterGroup>
+      <FilterGroup title="Season">
+        <SelectFilter
+          filterName={FilterName.Season}
+          options={seasonOptions}
+          urlQueryConfig={urlPropsQueryConfig[FilterName.Season]}
+          stacked
+        />
+      </FilterGroup>
       <FilterGroup title="Gender">
         <OptionListFilter
           filterName={FilterName.Gender}
@@ -93,7 +105,7 @@ const MemberFilterSet = ({ teams }) => {
           options={genderOptions}
         />
       </FilterGroup>
-      <FilterGroup title="Current Squad">
+      <FilterGroup title="Squad">
         <OptionListFilter
           filterName={FilterName.Team}
           urlQueryConfig={urlPropsQueryConfig[FilterName.Team]}
@@ -120,6 +132,7 @@ MemberFilterSet.propTypes = {
       long_name: PropTypes.string,
     }),
   ).isRequired,
+  seasons: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
 export default MemberFilterSet;

--- a/src/frontend/js/components/members/MemberList/MemberListWrapper/MemberListWrapper.jsx
+++ b/src/frontend/js/components/members/MemberList/MemberListWrapper/MemberListWrapper.jsx
@@ -5,36 +5,50 @@ import { ViewType } from 'util/constants';
 import { ViewSwitcher, ViewSwitcherView } from 'components/common/ViewSwitcher';
 import MemberTable from './MemberTable';
 import MemberMarker from './MemberMarker';
-
-const MemberListWrapper = ({ canViewMap, data, viewType, onSelectViewType, ...props }) => (
-  <div>
-    {canViewMap ? (
-      <ViewSwitcher currentView={viewType} onSelectViewType={onSelectViewType}>
-        <ViewSwitcherView iconClass="fas fa-table" label={ViewType.List} />
-        <ViewSwitcherView iconClass="far fa-map" label={ViewType.Map} />
-      </ViewSwitcher>
-    ) : null}
-    {!canViewMap || viewType === ViewType.List ? (
-      <MemberTable members={data.results} {...props} />
-    ) : (
-      <GoogleMap
-        markers={data.results
-          .filter(member => member.addrPosition)
-          .map(member => <MemberMarker key={member.id} member={member} />)}
-      />
-    )}
-  </div>
-);
+const MemberListWrapper = ({ canViewMap, data, viewType, onSelectViewType, networkStatus, loading, ...props }) => {
+  const isLoading = loading || networkStatus === 1 || networkStatus === 2 || networkStatus === 4;
+  const hasData = data && data.results;
+  
+  return (
+    <div>
+      {canViewMap ? (
+        <ViewSwitcher currentView={viewType} onSelectViewType={onSelectViewType}>
+          <ViewSwitcherView iconClass="fas fa-table" label={ViewType.List} />
+          <ViewSwitcherView iconClass="far fa-map" label={ViewType.Map} />
+        </ViewSwitcher>
+      ) : null}
+      {isLoading && (
+        <div className="text-center g-py-50">
+          <i className="fas fa-spinner fa-spin fa-3x g-color-primary"></i>
+          <p className="g-mt-20">Loading members...</p>
+        </div>
+      )}
+      {!isLoading && hasData && (!canViewMap || viewType === ViewType.List) ? (
+        <MemberTable members={data.results} {...props} />
+      ) : !isLoading && hasData && (
+        <GoogleMap
+          markers={data.results
+            .filter(member => member.addrPosition)
+            .map(member => <MemberMarker key={member.id} member={member} />)}
+        />
+      )}
+    </div>
+  );
+};
 
 MemberListWrapper.propTypes = {
   canViewMap: PropTypes.bool.isRequired,
   data: PropTypes.shape(),
   viewType: PropTypes.string.isRequired,
   onSelectViewType: PropTypes.func.isRequired,
+  networkStatus: PropTypes.number,
+  loading: PropTypes.bool,
 };
 
 MemberListWrapper.defaultProps = {
   data: undefined,
+  networkStatus: 7,
+  loading: false,
 };
 
 export default MemberListWrapper;

--- a/src/frontend/js/components/members/MemberList/MemberListWrapper/MemberListWrapper.jsx
+++ b/src/frontend/js/components/members/MemberList/MemberListWrapper/MemberListWrapper.jsx
@@ -5,7 +5,20 @@ import { ViewType } from 'util/constants';
 import { ViewSwitcher, ViewSwitcherView } from 'components/common/ViewSwitcher';
 import MemberTable from './MemberTable';
 import MemberMarker from './MemberMarker';
-const MemberListWrapper = ({ canViewMap, data, viewType, onSelectViewType, networkStatus, loading, ...props }) => {
+
+const MemberListWrapper = ({ 
+  canViewMap, 
+  data, 
+  viewType, 
+  onSelectViewType, 
+  networkStatus, 
+  loading,
+  sorted,
+  onChangePage,
+  onChangeSorted,
+  onChangeUrlQueryParams,
+  ...props 
+}) => {
   const isLoading = loading || networkStatus === 1 || networkStatus === 2 || networkStatus === 4;
   const hasData = data && data.results;
   
@@ -20,11 +33,18 @@ const MemberListWrapper = ({ canViewMap, data, viewType, onSelectViewType, netwo
       {isLoading && (
         <div className="text-center g-py-50">
           <i className="fas fa-spinner fa-spin fa-3x g-color-primary"></i>
-          <p className="g-mt-20">Loading members...</p>
+          <p className="g-mt-20">Loading members ...</p>
         </div>
       )}
       {!isLoading && hasData && (!canViewMap || viewType === ViewType.List) ? (
-        <MemberTable members={data.results} {...props} />
+        <MemberTable 
+          members={data.results} 
+          sorted={sorted}
+          onChangePage={onChangePage}
+          onChangeSorted={onChangeSorted}
+          onChangeUrlQueryParams={onChangeUrlQueryParams}
+          {...props} 
+        />
       ) : !isLoading && hasData && (
         <GoogleMap
           markers={data.results
@@ -43,12 +63,17 @@ MemberListWrapper.propTypes = {
   onSelectViewType: PropTypes.func.isRequired,
   networkStatus: PropTypes.number,
   loading: PropTypes.bool,
+  sorted: PropTypes.arrayOf(PropTypes.shape()),
+  onChangePage: PropTypes.func.isRequired,
+  onChangeSorted: PropTypes.func.isRequired,
+  onChangeUrlQueryParams: PropTypes.func.isRequired,
 };
 
 MemberListWrapper.defaultProps = {
   data: undefined,
   networkStatus: 7,
   loading: false,
+  sorted: [],
 };
 
 export default MemberListWrapper;

--- a/src/frontend/js/components/members/MemberList/MemberListWrapper/MemberTable/index.jsx
+++ b/src/frontend/js/components/members/MemberList/MemberListWrapper/MemberTable/index.jsx
@@ -67,6 +67,7 @@ const MemberTable = ({ members, page, pageSize, onChangePage, onChangeUrlQueryPa
       data={members || []}
       page={page}
       pageSize={pageSize}
+      minRows={members && members.length > 0 ? 0 : 5}
       onChangePage={onChangePage}
       onChangeUrlQueryParams={onChangeUrlQueryParams}
       getTdProps={(state, rowInfo) => ({

--- a/src/frontend/js/components/members/MemberList/MemberListWrapper/MemberTable/index.jsx
+++ b/src/frontend/js/components/members/MemberList/MemberListWrapper/MemberTable/index.jsx
@@ -48,6 +48,23 @@ const MemberTable = ({ members, page, pageSize, onChangePage, onChangeUrlQueryPa
           className: 'g-hidden-sm-down text-center',
           headerClassName: 'g-hidden-sm-down',
           width: 60,
+          sortMethod: (a, b) => {
+            if (!a && !b) return 0;
+            if (!a) return 1;
+            if (!b) return -1;
+            
+            const numA = parseInt(a, 10);
+            const numB = parseInt(b, 10);
+            
+            if (!isNaN(numA) && !isNaN(numB)) {
+              return numA - numB;
+            }
+            
+            if (!isNaN(numA)) return -1;
+            if (!isNaN(numB)) return 1;
+            
+            return String(a).localeCompare(String(b));
+          },
         },
         {
           Header: <abbr title="Appearances">Apps</abbr>,

--- a/src/frontend/js/components/members/MemberList/MemberListWrapper/MemberTable/index.jsx
+++ b/src/frontend/js/components/members/MemberList/MemberListWrapper/MemberTable/index.jsx
@@ -5,7 +5,7 @@ import commonStyles from 'components/common/style.scss';
 import Urls from 'util/urls';
 import styles from './style.scss';
 
-const MemberTable = ({ members, page, pageSize, onChangePage, onChangeUrlQueryParams }) => (
+const MemberTable = ({ members, page, pageSize, sorted, onChangePage, onChangeSorted, onChangeUrlQueryParams }) => (
   <div className={commonStyles.reactTable}>
     <UrlSyncedReactTable
       className="-highlight"
@@ -84,8 +84,10 @@ const MemberTable = ({ members, page, pageSize, onChangePage, onChangeUrlQueryPa
       data={members || []}
       page={page}
       pageSize={pageSize}
+      sorted={sorted}
       minRows={members && members.length > 0 ? 0 : 5}
       onChangePage={onChangePage}
+      onSortedChange={onChangeSorted}
       onChangeUrlQueryParams={onChangeUrlQueryParams}
       NoDataComponent={() => <div className="rt-noData">No members found</div>}
       getTdProps={(state, rowInfo) => ({
@@ -104,13 +106,16 @@ MemberTable.propTypes = {
   members: PropTypes.arrayOf(PropTypes.shape()).isRequired,
   pageSize: PropTypes.number,
   page: PropTypes.number,
+  sorted: PropTypes.arrayOf(PropTypes.shape()),
   onChangePage: PropTypes.func.isRequired,
+  onChangeSorted: PropTypes.func.isRequired,
   onChangeUrlQueryParams: PropTypes.func.isRequired,
 };
 
 MemberTable.defaultProps = {
   pageSize: 20,
   page: 1,
+  sorted: [],
 };
 
 export default MemberTable;

--- a/src/frontend/js/components/members/MemberList/MemberListWrapper/MemberTable/index.jsx
+++ b/src/frontend/js/components/members/MemberList/MemberListWrapper/MemberTable/index.jsx
@@ -70,6 +70,7 @@ const MemberTable = ({ members, page, pageSize, onChangePage, onChangeUrlQueryPa
       minRows={members && members.length > 0 ? 0 : 5}
       onChangePage={onChangePage}
       onChangeUrlQueryParams={onChangeUrlQueryParams}
+      NoDataComponent={() => <div className="rt-noData">No members found</div>}
       getTdProps={(state, rowInfo) => ({
         onClick: () => {
           window.location = Urls.member_detail(rowInfo.original.id);

--- a/src/frontend/js/components/members/MemberList/MemberListWrapper/index.jsx
+++ b/src/frontend/js/components/members/MemberList/MemberListWrapper/index.jsx
@@ -1,6 +1,6 @@
 import { compose } from 'react-apollo';
 import switchable from 'components/common/ViewSwitcher/switchableView';
-import { addUrlProps } from 'react-url-query';
+import { addUrlProps, UrlQueryParamTypes } from 'react-url-query';
 import Paged from 'components/common/Paged';
 import { SwitchableView } from 'util/constants';
 import MemberListQuery from './memberListQuery';
@@ -9,10 +9,29 @@ import { urlPropsQueryConfig } from '../MemberFilterSet';
 
 const SwitchableVenueListView = switchable(SwitchableView.MemberList);
 
+// Custom URL param type for sorting
+const SortUrlParam = {
+  encode: (sorted) => {
+    if (!sorted || sorted.length === 0) return undefined;
+    const sort = sorted[0]; // Only support single column sort
+    return sort.desc ? `-${sort.id}` : sort.id;
+  },
+  decode: (sortString) => {
+    if (!sortString) return [];
+    const desc = sortString.startsWith('-');
+    const id = desc ? sortString.substring(1) : sortString;
+    return [{ id, desc }];
+  },
+};
+
 const withUrlProps = addUrlProps({
   urlPropsQueryConfig: {
     ...urlPropsQueryConfig,
     ...Paged,
+    sorted: {
+      type: SortUrlParam,
+      queryParam: 'sort',
+    },
   },
 });
 

--- a/src/frontend/js/components/members/MemberList/MemberListWrapper/memberListQuery.jsx
+++ b/src/frontend/js/components/members/MemberList/MemberListWrapper/memberListQuery.jsx
@@ -27,7 +27,7 @@ export const MEMBER_LIST_QUERY = gql`
       prefPosition_In: $prefPosition_In
       teamcaptaincy_Season_Slug: $teamcaptaincy_Season_Slug
     ) {
-      results(pageSize: 1000) {
+      results(pageSize: 5000) {
         firstName
         lastName
         id

--- a/src/frontend/js/components/members/MemberList/MemberListWrapper/memberListQuery.jsx
+++ b/src/frontend/js/components/members/MemberList/MemberListWrapper/memberListQuery.jsx
@@ -15,6 +15,8 @@ export const MEMBER_LIST_QUERY = gql`
     $squadmembership_Team_Slug: String
     $prefPosition_In: String
     $teamcaptaincy_Season_Slug: String
+    $appearances_Match_Season_Slug: String
+    $appearances_Match_OurTeam_Slug: String
   ) {
     members(
       name: $name
@@ -26,6 +28,8 @@ export const MEMBER_LIST_QUERY = gql`
       squadmembership_Team_Slug: $squadmembership_Team_Slug
       prefPosition_In: $prefPosition_In
       teamcaptaincy_Season_Slug: $teamcaptaincy_Season_Slug
+      appearances_Match_Season_Slug: $appearances_Match_Season_Slug
+      appearances_Match_OurTeam_Slug: $appearances_Match_OurTeam_Slug
     ) {
       results(pageSize: 5000) {
         firstName
@@ -53,6 +57,7 @@ export const memberListOptions = {
     gender,
     position,
     team,
+    season,
   }) => ({
     variables: {
       name: textSearch || undefined,
@@ -61,16 +66,19 @@ export const memberListOptions = {
       isUmpire: umpires || undefined,
       isCoach: coaches || undefined,
       prefPosition_In: Member.getPreferredPositions(position),
-      squadmembership_Season_Slug: team && team !== NoFilter ? currentSeason : undefined,
-      squadmembership_Team_Slug: team && team !== NoFilter ? team : undefined,
-      teamcaptaincy_Season_Slug: captains ? currentSeason : undefined,
+      squadmembership_Season_Slug: undefined,
+      squadmembership_Team_Slug: undefined,
+      teamcaptaincy_Season_Slug: captains ? (season && season !== NoFilter ? season : currentSeason) : undefined,
+      appearances_Match_Season_Slug: season && season !== NoFilter ? season : undefined,
+      appearances_Match_OurTeam_Slug: team && team !== NoFilter ? team : undefined,
     },
     fetchPolicy: 'cache-and-network',
   }),
-  props: ({ data: { networkStatus, error, members }, ...props }) => ({
-    networkStatus,
-    error,
-    data: members,
+  props: ({ data, ...props }) => ({
+    networkStatus: data.networkStatus,
+    loading: data.loading,
+    error: data.error,
+    data: data.members,
     loadingMessage: 'Loading members...',
     ...props,
   }),

--- a/src/frontend/js/components/members/MemberList/index.jsx
+++ b/src/frontend/js/components/members/MemberList/index.jsx
@@ -4,8 +4,8 @@ import FilterableList from 'components/common/FilterableList';
 import MemberFilterSet from './MemberFilterSet';
 import MemberListWrapper from './MemberListWrapper';
 
-const MemberList = ({ canViewMap, currentSeason, teams }) => {
-  const filterSet = <MemberFilterSet teams={teams} />;
+const MemberList = ({ canViewMap, currentSeason, teams, seasons }) => {
+  const filterSet = <MemberFilterSet teams={teams} seasons={seasons} />;
   const listWrapper = <MemberListWrapper currentSeason={currentSeason} canViewMap={canViewMap} />;
   return <FilterableList filterSet={filterSet} listWrapper={listWrapper} />;
 };
@@ -19,6 +19,7 @@ MemberList.propTypes = {
       long_name: PropTypes.string,
     }),
   ).isRequired,
+  seasons: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
 export default MemberList;

--- a/src/frontend/js/util/constants.js
+++ b/src/frontend/js/util/constants.js
@@ -177,7 +177,7 @@ const DefaultPageSize = 10;
 /**
  * The default page size options for paginated results
  */
-const DefaultPageSizeOptions = [10, 20, 25, 50];
+const DefaultPageSizeOptions = [10, 20, 25, 50, 100];
 
 module.exports = {
   Gender,

--- a/src/members/schema.py
+++ b/src/members/schema.py
@@ -241,6 +241,9 @@ def post_optimize_members(queryset, **kwargs):
     queryset = queryset.annotate(num_appearances=Count(
         'appearances'), goals=Sum('appearances__goals'))
 
+    # Sort by known_as (or first_name if known_as is empty), then last_name
+    queryset = queryset.order_by('known_as', 'first_name', 'last_name')
+
     return queryset
 
 

--- a/src/members/views.py
+++ b/src/members/views.py
@@ -45,6 +45,7 @@ class MemberListView(TemplateView):
             'canViewMap': self.request.user.has_perm('members.view_personal_data'),
             'currentSeason': current_season.slug,
             'teams': list(ClubTeam.objects.active().exclude(slug__in=['mv', 'lv', 'm-in', 'l-in', 'mixed-a', 'mixed-b']).values('long_name', 'slug')),
+            'seasons': list(Season.objects.all().order_by('-slug').values_list('slug', flat=True)),
         }
         return context
 

--- a/src/members/views.py
+++ b/src/members/views.py
@@ -44,7 +44,7 @@ class MemberListView(TemplateView):
         context['props'] = {
             'canViewMap': self.request.user.has_perm('members.view_personal_data'),
             'currentSeason': current_season.slug,
-            'teams': list(ClubTeam.objects.active().exclude(slug__in=['mv', 'lv', 'm-in', 'l-in', 'mixed-a', 'mixed-b']).values('long_name', 'slug')),
+            'teams': list(ClubTeam.objects.active().values('long_name', 'slug')),
             'seasons': list(Season.objects.all().order_by('-slug').values_list('slug', flat=True)),
         }
         return context


### PR DESCRIPTION
This change adds something I've wanted for a while - member search by season - and makes a few other enhancements to the member search page.

* Add Season as a filter for searching members - shows anyone with an appearance that season
* Change Current Squad to Squad and filter by appearances rather than squad assignment - we don't seem to have had squads assigned for the last couple of seasons
* Increase the maximum page size to 5000 so that all 1351 members can be returned
* Sort the member search results by `known_as` then `first_name` to align with the way it is displayed - see any list with 'Nooshi Trivedi' in it
* Add 100 rows as an option and remove the blank rows from the results table when there are fewer records than the page size
* Change the text when there are no records to "No members found" instead of "No rows found"
* Displays a "spinner" while the data is loading - this may not be needed in prod, but locally some of the queries take a couple of seconds, so this seemed like a good idea

I'd suggest a couple of other changes to member search (like making the squad selection a drop-down) but I thought this was enough for one change.

**UPDATE:** I added two more changes:
* The Squad filter is now named Team and shows all the teams - vets and indoor were previously excluded but now it is consistent with Match Search. If there was a reason why these teams were previously excluded I can undo this
* Made Gender and Team (was Squad) drop-down selectors rather than radio buttons - again, for consistency and because the team list was getting long as a list of radio buttons