### PR TITLE
Show 20 rows of matches by default

### DIFF
--- a/src/frontend/js/components/matches/MatchList/MatchListWrapper/MatchListWrapper.jsx
+++ b/src/frontend/js/components/matches/MatchList/MatchListWrapper/MatchListWrapper.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import MatchListDisplay from 'components/matches/MatchListDisplay';
-import { DefaultPageSize } from 'util/constants';
 
 const MatchListWrapper = ({
   page,
@@ -65,7 +64,7 @@ MatchListWrapper.propTypes = {
 };
 
 MatchListWrapper.defaultProps = {
-  pageSize: DefaultPageSize,
+  pageSize: 20,
   page: 1,
   orderBy: undefined,
   gender: undefined,

--- a/src/frontend/js/components/matches/MatchListDisplay/MatchListDisplay.jsx
+++ b/src/frontend/js/components/matches/MatchListDisplay/MatchListDisplay.jsx
@@ -116,6 +116,7 @@ class MatchListDisplay extends React.Component {
           loading={loading}
           page={page}
           pageSize={pageSize}
+          minRows={matches && matches.length > 0 ? 0 : 5}
           onChangePage={onChangePage}
           onChangeUrlQueryParams={onChangeUrlQueryParams}
           onSortedChange={this.onSortedChange}


### PR DESCRIPTION
Increase the default number of matches shown from 10 to 20, and limit the size of the table when there are fewer records than the page size (same as PR for the member search)