### PR TITLE
Fix score input so first digit is 0, not 1

### DIFF
--- a/src/frontend/js/components/common/NumberInput/index.jsx
+++ b/src/frontend/js/components/common/NumberInput/index.jsx
@@ -37,7 +37,13 @@ const NumberInput = ({
       <button
         disabled={disabled}
         className="btn btn-link g-pa-0"
-        onClick={() => onChangeValue((value || 0) + 1)}
+        onClick={() => {
+          if (value === undefined || value === null) {
+            onChangeValue(0);
+          } else {
+            onChangeValue(value + 1);
+          }
+        }}
       >
         <i className={upIconClass} />
       </button>


### PR DESCRIPTION
Resolves a bug where to set a score to 0 you had to set it to 1 and then back to 0. This change makes the first digit displayed after pressing the 'up' button 0 instead of 1.