### PR TITLE
New East Hockey league scraper

### DIFF
--- a/src/core/management/commands/nightly_tasks.py
+++ b/src/core/management/commands/nightly_tasks.py
@@ -72,19 +72,10 @@ class Command(BaseCommand):
             errors.append("Failed to purge training sessions: {}".format(e))
 
         # Scrape league tables
-        query = Q(division_tables_url__isnull=True) | Q(division_tables_url='')
-        participations = ClubTeamSeasonParticipation.objects.current(
-        ).exclude(query).select_related('team', 'division')
-
-        for participation in participations:
-            try:
-                league_scraper.get_hockey_east_division(
-                    participation.division_tables_url, participation.division, season)
-                print('Scraped league table for ' +
-                      participation.division_tables_url)
-            except Exception as e:
-                errors.append("Failed to scrape league table from {}: {}".format(
-                    participation.division_tables_url, e))
+        try:
+            call_command('scrape_leagues')
+        except Exception as e:
+            errors.append("Failed to scrape leagues: {}".format(e))
 
         # Backup database
         try:

--- a/src/core/management/commands/scrape_leagues.py
+++ b/src/core/management/commands/scrape_leagues.py
@@ -1,0 +1,119 @@
+""" Management command that sccrapes England Hockey website for league tables
+
+    Usage:
+    python manage.py scrape_leagues                                 # Scrapes all teams for the current season
+    python manage.py scrape_leagues --season 2024-2025              # Scrapes all teams for the 2024-2025 season
+    python manage.py scrape_leagues --team m1                       # Scrapes M1 for the current season
+    python manage.py scrape_leagues --team m1 --season 2024-2025    # Scrapes M1 for the 2024-2025 season
+"""
+
+import logging
+from django.db.models import Q
+from django.core.management.base import BaseCommand
+from competitions.models import Season
+from teams import league_scraper
+from teams.models import ClubTeamSeasonParticipation, ClubTeam
+
+LOG = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Command for scraping league tables from England Hockey."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--team',
+            type=str,
+            help='Optional: Slug of a specific team to scrape (e.g., m1). If omitted, all teams for the target season will be scraped.',
+        )
+        parser.add_argument(
+            '--season',
+            type=str,
+            help='Optional: Slug of a specific season to scrape (e.g., 2024-2025). If omitted, the current season will be used.',
+        )
+
+    def _scrape_single_participation(self, participation, errors_list):
+        """Helper method to encapsulate the scraping logic for a single participation."""
+        LOG.debug(f"Scraping for Team: {participation.team}")
+        LOG.debug(f"  Gender:   {participation.team.gender}")
+        LOG.debug(f"  Division: {participation.division}")
+        LOG.debug(f"  URL:      {participation.division_tables_url}")
+
+        try:
+            # Call the new API-based scraper function
+            league_scraper.get_east_england_hockey_division(
+                participation.division_tables_url,
+                participation.division,
+                participation.season,
+                participation.team
+            )
+            LOG.debug(f'Successfully scraped league table for {participation.division_tables_url}')
+        except Exception as e:
+            errors_list.append(f"Failed to scrape league table from {participation.division_tables_url}: {e}")
+            LOG.error(self.style.ERROR(f"  Error: {e}")) # Also print error immediately for context
+
+    def handle(self, *args, **options):
+        errors = []
+        team_slug = options['team']
+        season_slug = options['season']
+
+        target_season_obj = None
+        target_team_obj = None
+        
+        # 1. Determine the target season
+        if season_slug:
+            try:
+                target_season_obj = Season.objects.get(slug=season_slug)
+                LOG.info(f"Targeting season: {target_season_obj.slug}")
+            except Season.DoesNotExist:
+                errors.append(f"ERROR: Season with slug '{season_slug}' not found.")
+                LOG.error(self.style.ERROR(errors[-1]))
+                return # Cannot proceed without a valid season
+        else:
+            target_season_obj = Season.current()
+            LOG.info(f"No season specified. Defaulting to current season: {target_season_obj.slug}")
+
+        # 2. Determine the target team (if any)
+        if team_slug:
+            try:
+                target_team_obj = ClubTeam.objects.get(slug=team_slug)
+                LOG.info(f"Targeting team: {target_team_obj.short_name}")
+            except ClubTeam.DoesNotExist:
+                errors.append(f"ERROR: Team with slug '{team_slug}' not found.")
+                LOG.error(self.style.ERROR(errors[-1]))
+                return # Cannot proceed without a valid team if specified
+
+        # 3. Build the initial queryset for participations
+        participations_queryset = ClubTeamSeasonParticipation.objects.filter(
+            season=target_season_obj
+        )
+
+        # 4. Apply team filter if a specific team was provided
+        if target_team_obj:
+            participations_queryset = participations_queryset.filter(team=target_team_obj)
+            LOG.info(f"Scraping specific participation for team '{target_team_obj.short_name}' in season '{target_season_obj.slug}'...")
+        else:
+            LOG.info(f"Scraping all teams for season '{target_season_obj.slug}'...")
+
+        # 5. Always filter out participations without a division_tables_url and select related objects
+        participations_queryset = participations_queryset.exclude(
+            Q(division_tables_url__isnull=True) | Q(division_tables_url='')
+        ).select_related('team', 'division')
+
+        if not participations_queryset.exists():
+            LOG.info(f"No relevant participations found with a league table URL for "
+                              f"team: {target_team_obj.short_name if target_team_obj else 'all'} "
+                              f"in season: {target_season_obj.slug}.")
+            return # Exit if no participations to process
+
+        # 6. Iterate and scrape
+        for participation in participations_queryset:
+            self._scrape_single_participation(participation, errors)
+
+        if errors:
+            LOG.error(self.style.ERROR("\n--- Scraping Errors ---"))
+            for error in errors:
+                LOG.error(self.style.ERROR(error))
+            LOG.error(self.style.ERROR("--- End Errors ---"))
+        else:
+            LOG.info(self.style.SUCCESS("\nLeague scraping completed successfully with no errors."))

--- a/src/frontend/js/components/competitions/LeagueTable/LeagueTable.jsx
+++ b/src/frontend/js/components/competitions/LeagueTable/LeagueTable.jsx
@@ -92,7 +92,18 @@ class LeagueTable extends React.PureComponent {
                     <td>{row.goalsAgainst}</td>
                     <td>{relative(row.goalDifference)}</td>
                     <td>{row.points}</td>
-                    <td>{row.notes}</td>
+                    <td>
+                      {row.notes && row.notes.trim() !== '' ? (
+                        <span
+                          id={`note-tooltip-${row.teamName.replace(/\s/g, '-')}`}
+                          title={row.notes}
+                          className="far fa-file-alt" 
+                          style={{ cursor: 'pointer' }}
+                        ></span>
+                      ) : (
+                        ''
+                      )}
+                    </td>
                   </tr>
                 );
               })}

--- a/src/teams/league_scraper.py
+++ b/src/teams/league_scraper.py
@@ -13,6 +13,9 @@
 import logging
 from urllib.request import urlopen
 from bs4 import BeautifulSoup
+import requests
+import re
+from urllib.parse import urlparse
 from django.db.models import Q
 from competitions.models import DivisionResult
 from matches.models import Match
@@ -26,6 +29,44 @@ def parse_url(url):
     """ Reads the contents of specified url and returns a BeautifulSoup object that wraps it"""
     source = urlopen(url).read()
     return BeautifulSoup(source, "html5lib")
+
+
+def rewrite_team_name(raw_name):
+    """
+    Applies a series of substitutions to team names.
+    Substitutions are applied sequentially and case-insensitively.
+    Replacement strings can be empty to remove parts of the name.
+    """
+    # Define substitutions as (regex_pattern, replacement_string) tuples.
+    # Patterns are applied case-insensitively.
+    # Use re.escape() for literal strings to ensure special regex characters are handled.
+    # Use \b for whole word matching where appropriate (e.g., for "Development").
+    substitutions = [
+        (re.escape("city of peterborough"), "City of Peterborough"),
+        (re.escape("ipswich-east suffolk"), "Ipswich & East Suffolk"),
+        (re.escape("blueharts m1"), "Blueharts 1"),
+        (r"\bdevelopment\b", ""), # Removes "Development" as a whole word
+        # Add more substitutions here as (pattern, replacement) tuples.
+    ]
+
+    cleaned_name = raw_name.strip()
+    original_name_for_log = cleaned_name
+
+    for pattern, replacement in substitutions:
+        # Apply substitution case-insensitively
+        new_name = re.sub(pattern, replacement, cleaned_name, flags=re.IGNORECASE)
+        if new_name != cleaned_name:
+            LOG.debug(f"  Applied substitution '{pattern}' -> '{replacement}': '{cleaned_name}' -> '{new_name}'")
+            cleaned_name = new_name
+
+    # Clean up any multiple spaces that might result from removals, and re-strip
+    cleaned_name = re.sub(r'\s+', ' ', cleaned_name).strip()
+
+    if original_name_for_log != cleaned_name:
+        LOG.debug("Team name rewritten: '{}' -> '{}'".format(raw_name, cleaned_name))
+    
+    return cleaned_name
+
 
 def get_hockey_east_division(url, division, season):
     existing_teams = DivisionResult.objects.league_table(
@@ -125,11 +166,233 @@ def get_east_leagues_division(url, division, season):
     return teams
 
 
+def get_east_england_hockey_division(page_url, division, season_obj, team_name=None):
+    """
+    Scrapes the league table data directly from the England Hockey API,
+    following a structured sequence of API calls.
+
+    Args:
+        page_url (str): The initial URL to scrape for the API base URL and key.
+        division (competitions.models.Division): The Division object, containing
+                                                 name, short_name, and gender.
+        season_obj (competitions.models.Season): The local Season object for which
+                                                  to scrape data. Its slug (e.g., "2024-2025")
+                                                  will be used for API matching.
+
+    Returns:
+        list[DivisionResult]: A list of DivisionResult objects parsed from the API.
+    """
+    # Use the passed-in season_obj directly
+    existing_teams = DivisionResult.objects.league_table(
+        season=season_obj, division=division)
+    division_results = []
+    api_base_url = None
+    api_key = None
+
+    # Suppress InsecureRequestWarning when verify=False
+    requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
+
+    try:
+        # Step 1: Call the full URL to get the API key and base URL, and filter IDs
+        LOG.debug(f"Step 1: Fetching main page to extract API details and filter IDs from {page_url}")
+        main_page_response = requests.get(page_url, timeout=10, verify=False)
+        main_page_response.raise_for_status()
+        soup = BeautifulSoup(main_page_response.text, "html5lib")
+
+        competition_table_div = soup.find('div', {'data-module': 'competitions-table'})
+        if not competition_table_div:
+            LOG.error(f"Could not find data-module='competitions-table' div on {page_url}")
+            return []
+
+        api_base_url = competition_table_div.get('data-url')
+        api_key = competition_table_div.get('data-url-key')
+
+        if not api_base_url or not api_key:
+            LOG.error(f"Could not extract API base URL or API key from {page_url}")
+            return []
+        LOG.debug(f"API Base URL: {api_base_url}, API Key: {api_key[:5]}...") # Log partial key for security
+
+        # Extract IDs directly from the HTML select elements
+        season_select = soup.find('select', {'id': 'season'})
+        extracted_season_id = season_select.get('data-selected-id') if season_select else None
+
+        comp_group_select = soup.find('select', {'id': 'competition-group'})
+        extracted_competition_group_id = comp_group_select.get('data-selected-id') if comp_group_select else None
+        extracted_area_id = comp_group_select.get('data-area-id') if comp_group_select else None
+
+        if not all([extracted_season_id, extracted_competition_group_id, extracted_area_id]):
+            LOG.error(f"Could not extract all required IDs from {page_url}. "
+                      f"Season ID: {extracted_season_id}, Comp Group ID: {extracted_competition_group_id}, Area ID: {extracted_area_id}")
+            return []
+        LOG.debug(f"Extracted IDs from HTML: Season={extracted_season_id}, CompGroup={extracted_competition_group_id}, Area={extracted_area_id}")
+
+        headers = {"x-api-key": api_key, "Accept": "application/json"}
+
+        # Step 2: Construct and call the competitionGroups URL directly using extracted IDs
+        full_competition_groups_url = f"{api_base_url}/seasons/{extracted_season_id}/areas/{extracted_area_id}/competitiongroups"
+        LOG.debug(f"Step 2: Fetching competition groups from {full_competition_groups_url}")
+        competition_groups_response = requests.get(full_competition_groups_url, headers=headers, timeout=30, verify=False)
+        competition_groups_response.raise_for_status()
+        competition_groups_data = competition_groups_response.json()
+
+        target_competition_group = None
+        for cg in competition_groups_data:
+            if not isinstance(cg, dict):
+                LOG.warning(f"Skipping non-dictionary competition group entry: {cg} (Type: {type(cg)})")
+                continue
+            # Match by the extracted competition group ID
+            if cg.get('id') == extracted_competition_group_id:
+                target_competition_group = cg
+                LOG.debug(f"Matched competition group by ID: '{extracted_competition_group_id}'")
+                break
+        
+        if not target_competition_group:
+            all_cg_ids = [cg.get('id', 'N/A') for cg in competition_groups_data if isinstance(cg, dict)]
+            LOG.error(f"Could not find competition group with ID '{extracted_competition_group_id}' in API response. "
+                      f"Available IDs: {all_cg_ids}")
+            return []
+        
+        # The 'links' field is a list, not a dictionary. Iterate to find the correct one.
+        competition_group_links = target_competition_group.get('links', [])
+        tables_link = None
+        for link_item in competition_group_links:
+            if link_item.get('href') and link_item['href'].endswith('/tables'):
+                tables_link = link_item['href']
+                break
+
+        if not tables_link: # Check if we found the link
+            LOG.error(f"Competition group '{target_competition_group.get('name')}' found but missing 'tables' link in its 'links' list.")
+            return []
+
+        LOG.debug(f"Found competition group '{target_competition_group.get('name')}' with API ID: {target_competition_group.get('id')}")
+
+        # Step 3: Get the 'tables' URL from the competition group and use that to pull in the data
+        # The tables_link from the API is already a full URL, no need to prepend api_base_url
+        full_tables_url = tables_link
+        LOG.debug(f"Step 3: Fetching tables data from {full_tables_url}")
+        tables_response = requests.get(full_tables_url, headers=headers, timeout=10, verify=False)
+        tables_response.raise_for_status()
+        api_response_for_tables_endpoint = tables_response.json()
+
+        if not api_response_for_tables_endpoint:
+            LOG.warning(f"API returned no data for tables endpoint {full_tables_url}.")
+            return []
+
+        # Expecting api_response_for_tables_endpoint to be a dictionary with a 'data' key
+        if not isinstance(api_response_for_tables_endpoint, dict) or 'data' not in api_response_for_tables_endpoint:
+            LOG.error(f"Unexpected API tables response format. Expected a dictionary with a 'data' key. Got: {type(api_response_for_tables_endpoint)}. "
+                      f"Keys: {list(api_response_for_tables_endpoint.keys()) if isinstance(api_response_for_tables_endpoint, dict) else 'N/A'}")
+            return []
+        
+        # This is the list of division table dictionaries from the API's 'data' field
+        # Each item in this list is a dictionary representing a division's full table data
+        division_tables_from_api_data = api_response_for_tables_endpoint['data']
+        if not isinstance(division_tables_from_api_data, list):
+            LOG.error(f"Expected 'data' field to be a list, but got {type(division_tables_from_api_data)}")
+            return []
+
+        # Extract the entityUrlSlug from the page_url to match against API response
+        parsed_page_url = urlparse(page_url)
+        # The slug is typically the second to last segment of the path
+        page_url_slug = parsed_page_url.path.split('/')[-2]
+        LOG.debug(f"Derived page_url_slug from database URL: '{page_url_slug}'")
+
+        target_division_table_entry = None
+        all_available_division_table_slugs = [] # For better error logging
+
+        # Iterate directly through the list of division table entries
+        for current_division_entry in division_tables_from_api_data:
+            if not isinstance(current_division_entry, dict):
+                LOG.warning(f"Skipping non-dictionary division table entry: {current_division_entry} (Type: {type(current_division_entry)})")
+                continue
+            
+            current_division_table_slug = current_division_entry.get('entityUrlSlug')
+            if current_division_table_slug:
+                all_available_division_table_slugs.append(current_division_table_slug) # Collect all slugs for error message
+
+            # This is the direct match we're looking for
+            if current_division_table_slug == page_url_slug:
+                target_division_table_entry = current_division_entry
+                LOG.debug(f"Matched specific division table by entityUrlSlug: '{current_division_table_slug}'")
+                break # Found the specific table, break the loop
+        
+        if not target_division_table_entry:
+            LOG.error(f"Could not find division table matching entityUrlSlug '{page_url_slug}' "
+                      f"within the API's 'data' list. "
+                      f"Available division table slugs: {', '.join(all_available_division_table_slugs) if all_available_division_table_slugs else 'None'}")
+            return []
+        
+        # Now that we have the correct division entry, extract the 'table' (list of teams) from it
+        eh_division_name = target_division_table_entry.get('name')
+        team_list = target_division_table_entry.get('table', []) # <--- Correctly accessing 'table' key which holds the list of teams
+        if not isinstance(team_list, list):
+            LOG.error(f"Expected 'table' field within matched division entry to be a list, but got {type(team_list)}")
+            return []
+
+        if not team_list:
+            LOG.warning(f"No teams found in the target table for division '{division.name}'.")
+            return []
+        LOG.debug(f"Found table data for division '{division.name}' with {len(team_list)} teams.")
+
+        # Step 4: Parse the data we get to scrape the results
+        for i, team_data in enumerate(team_list):
+            if not isinstance(team_data, dict):
+                LOG.warning(f"Skipping non-dictionary team data entry: {team_data} (Type: {type(team_data)})")
+                continue
+
+            dr = DivisionResult()
+            dr.division = division
+            dr.season = season_obj
+            dr.position = i + 1 # Assign position based on 1-indexed list order
+                                                     
+            name = team_data.get('teamName')
+            # Removed: name = _clean_team_name(name)
+            set_team(dr, name, division)
+
+            dr.played = team_data.get('gamesPlayed', 0)
+            dr.won = team_data.get('gamesWon', 0)
+            dr.drawn = team_data.get('gamesDrawn', 0)
+            dr.lost = team_data.get('gamesLost', 0)
+            dr.goals_for = team_data.get('goalsFor', 0)
+            dr.goals_against = team_data.get('goalsAgainst', 0)
+            dr.goal_difference = team_data.get('goalsDifference', 0)
+            dr.points = team_data.get('totalPoints', 0)
+            dr.notes = team_data.get('pointsAdjustmentNotes', '')
+
+            division_results.append(dr)
+            LOG.debug(f"Parsed team from API: {dr}")
+
+    except requests.exceptions.RequestException as e:
+        LOG.error(f"API request failed for {division.name} ({season_obj.slug}): {e}", exc_info=True)
+        return []
+    except (KeyError, TypeError, AttributeError) as e:
+        LOG.error(f"API response structure unexpected for {division.name} ({season_obj.slug}). Error: {e}. "
+                  f"Context: api_base_url={api_base_url}, api_key={api_key[:5] if api_key else 'N/A'}...", exc_info=True)
+        return []
+    except Exception as e:
+        LOG.error(f"An unexpected error occurred during API scraping for {division.name} ({season_obj.slug}): {e}", exc_info=True)
+        return []
+
+    # Only replace existing entries if we've got at least as many entries
+    # This is a safeguard against partial scrapes due to API issues or incomplete data.
+    if len(division_results) >= len(existing_teams) and len(division_results) > 0:
+        existing_teams.delete()
+        for dr in division_results:
+            dr.save()
+        LOG.info(f"Successfully updated {team_name}'s results for '{eh_division_name}' ({season_obj.slug}) from API.")
+    else:
+        LOG.warning(f"Did not save division results for {eh_division_name} ({season_obj.slug}) from API: "
+                    f"Only {len(division_results)} teams parsed (previously {len(existing_teams)} teams). "
+                    "This might indicate a problem with the API or an empty response, or that the new data is less complete.")
+    return division_results
+
+
 def set_team(team, name, division):
     """ Works out whether the team should be a CSHC team (ClubTeam) or
         an opposition team (Team). Also handles the lack of the text 'Ladies'
         in the team name.
     """
+    name = rewrite_team_name(name)
 
     try:
         if name.startswith('Cambridge South '):

--- a/src/teams/league_scraper.py
+++ b/src/teams/league_scraper.py
@@ -170,14 +170,25 @@ def get_east_england_hockey_division(page_url, division, season_obj, team_name=N
     """
     Scrapes the league table data directly from the England Hockey API,
     following a structured sequence of API calls.
+    
+    1. Open the initial page URL to extract the necessary IDs (season, competition
+       group, area), and the API base URL and API key from the HTML.
+    2. Use the extracted IDs to call the competitionGroups API endpoint and find the
+       specific competition group that matches the division.
+    3. From the matched competition group, retrieve the 'tables' link and call it
+       to get the full league table data.
+    4. Parse the returned JSON data to extract the relevant division table and its teams,
+       creating DivisionResult objects for each team.
 
     Args:
         page_url (str): The initial URL to scrape for the API base URL and key.
         division (competitions.models.Division): The Division object, containing
                                                  name, short_name, and gender.
         season_obj (competitions.models.Season): The local Season object for which
-                                                  to scrape data. Its slug (e.g., "2024-2025")
-                                                  will be used for API matching.
+                                                 to scrape data. Its slug (e.g., "2024-2025")
+                                                 will be used for API matching.
+        team_name (str, optional): The name of the team being scraped. Used for logging
+                                   purposes. Defaults to None.
 
     Returns:
         list[DivisionResult]: A list of DivisionResult objects parsed from the API.
@@ -210,7 +221,7 @@ def get_east_england_hockey_division(page_url, division, season_obj, team_name=N
         if not api_base_url or not api_key:
             LOG.error(f"Could not extract API base URL or API key from {page_url}")
             return []
-        LOG.debug(f"API Base URL: {api_base_url}, API Key: {api_key[:5]}...") # Log partial key for security
+        LOG.debug(f"API Base URL: {api_base_url}, API Key: {api_key[:5]}...")
 
         # Extract IDs directly from the HTML select elements
         season_select = soup.find('select', {'id': 'season'})
@@ -298,7 +309,7 @@ def get_east_england_hockey_division(page_url, division, season_obj, team_name=N
         LOG.debug(f"Derived page_url_slug from database URL: '{page_url_slug}'")
 
         target_division_table_entry = None
-        all_available_division_table_slugs = [] # For better error logging
+        all_available_division_table_slugs = []
 
         # Iterate directly through the list of division table entries
         for current_division_entry in division_tables_from_api_data:
@@ -308,7 +319,7 @@ def get_east_england_hockey_division(page_url, division, season_obj, team_name=N
             
             current_division_table_slug = current_division_entry.get('entityUrlSlug')
             if current_division_table_slug:
-                all_available_division_table_slugs.append(current_division_table_slug) # Collect all slugs for error message
+                all_available_division_table_slugs.append(current_division_table_slug)
 
             # This is the direct match we're looking for
             if current_division_table_slug == page_url_slug:
@@ -324,7 +335,7 @@ def get_east_england_hockey_division(page_url, division, season_obj, team_name=N
         
         # Now that we have the correct division entry, extract the 'table' (list of teams) from it
         eh_division_name = target_division_table_entry.get('name')
-        team_list = target_division_table_entry.get('table', []) # <--- Correctly accessing 'table' key which holds the list of teams
+        team_list = target_division_table_entry.get('table', [])
         if not isinstance(team_list, list):
             LOG.error(f"Expected 'table' field within matched division entry to be a list, but got {type(team_list)}")
             return []
@@ -343,10 +354,9 @@ def get_east_england_hockey_division(page_url, division, season_obj, team_name=N
             dr = DivisionResult()
             dr.division = division
             dr.season = season_obj
-            dr.position = i + 1 # Assign position based on 1-indexed list order
+            dr.position = i + 1
                                                      
             name = team_data.get('teamName')
-            # Removed: name = _clean_team_name(name)
             set_team(dr, name, division)
 
             dr.played = team_data.get('gamesPlayed', 0)

--- a/src/teams/league_scraper.py
+++ b/src/teams/league_scraper.py
@@ -189,13 +189,13 @@ def get_east_england_hockey_division(page_url, division, season_obj, team_name=N
     api_base_url = None
     api_key = None
 
-    # Suppress InsecureRequestWarning when verify=False
-    requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
+    request_timeout = 10
+    request_verify = True
 
     try:
         # Step 1: Call the full URL to get the API key and base URL, and filter IDs
         LOG.debug(f"Step 1: Fetching main page to extract API details and filter IDs from {page_url}")
-        main_page_response = requests.get(page_url, timeout=10, verify=False)
+        main_page_response = requests.get(page_url, timeout=request_timeout, verify=request_verify)
         main_page_response.raise_for_status()
         soup = BeautifulSoup(main_page_response.text, "html5lib")
 
@@ -231,7 +231,7 @@ def get_east_england_hockey_division(page_url, division, season_obj, team_name=N
         # Step 2: Construct and call the competitionGroups URL directly using extracted IDs
         full_competition_groups_url = f"{api_base_url}/seasons/{extracted_season_id}/areas/{extracted_area_id}/competitiongroups"
         LOG.debug(f"Step 2: Fetching competition groups from {full_competition_groups_url}")
-        competition_groups_response = requests.get(full_competition_groups_url, headers=headers, timeout=30, verify=False)
+        competition_groups_response = requests.get(full_competition_groups_url, headers=headers, timeout=request_timeout, verify=request_verify)
         competition_groups_response.raise_for_status()
         competition_groups_data = competition_groups_response.json()
 
@@ -270,7 +270,7 @@ def get_east_england_hockey_division(page_url, division, season_obj, team_name=N
         # The tables_link from the API is already a full URL, no need to prepend api_base_url
         full_tables_url = tables_link
         LOG.debug(f"Step 3: Fetching tables data from {full_tables_url}")
-        tables_response = requests.get(full_tables_url, headers=headers, timeout=10, verify=False)
+        tables_response = requests.get(full_tables_url, headers=headers, timeout=request_timeout, verify=request_verify)
         tables_response.raise_for_status()
         api_response_for_tables_endpoint = tables_response.json()
 


### PR DESCRIPTION
Adds a new scraper which works with the current East Hockey / England Hockey website. 

Includes a new Django management command wrapper by default scrapes the current season, but can also takes team and season as arguments, so we can backfill the past four seasons from the EH website. The nightly_tasks will use this new command.

Also includes a change to league table display to show notes as an icon with a tooltip because rather than just putting the points deducted in the notes, they now list all the reasons, which messes up the table formatting.