### PR TITLE
Teams and Team Photos

### DIFF
--- a/src/cshc/context_processors.py
+++ b/src/cshc/context_processors.py
@@ -34,10 +34,10 @@ def utils(request):
                     ('m4', 'Mens 4ths',),
                     ('m5', 'Mens 5ths',),
                     ('m6', 'Mens 6ths',),
-                    ('m7', 'Mens 7ths',),
+                    #('m7', 'Mens 7ths',),
                     # Add a border above this item
-                    ('m-in', 'Mens Indoor', True),
-                    ('mv', 'Mens Vets',),
+                    #('m-in', 'Mens Indoor', True),
+                    ('mv', 'Mens Vets', True),
                 ],
             },
             {
@@ -49,10 +49,10 @@ def utils(request):
                     ('l4', 'Ladies 4ths',),
                     ('l5', 'Ladies 5ths',),
                     ('l6', 'Ladies 6ths',),
-                    ('l7', 'Ladies 7ths',),
+                    #('l7', 'Ladies 7ths',),
                     # Add a border above this item
-                    ('l-in', 'Ladies Indoor', True),
-                    ('lv', 'Ladies Vets',),
+                    #('l-in', 'Ladies Indoor', True),
+                    ('lv', 'Ladies Vets', True),
                 ],
             },
             {

--- a/src/cshc/templates/teams/clubteam_list.html
+++ b/src/cshc/templates/teams/clubteam_list.html
@@ -34,9 +34,6 @@
     <li class="list-inline-item cbp-filter-item g-brd-around g-brd-gray-light-v4 g-brd-primary--active g-color-gray-dark-v4 g-color-primary--hover g-color-primary--active g-font-size-12 rounded g-transition-0_3 g-px-20 g-py-7 mb-2" role="button" data-filter=".Other">
       Other
     </li>
-    <li class="list-inline-item cbp-filter-item g-brd-around g-brd-gray-light-v4 g-brd-primary--active g-color-gray-dark-v4 g-color-primary--hover g-color-primary--active g-font-size-12 rounded g-transition-0_3 g-px-20 g-py-7 mb-2" role="button" data-filter=".Inactive">
-      Inactive
-    </li>
   </ul>
 
   <div class="cbp" data-controls="#filterControls" data-animation="quicksand" data-x-gap="30" data-y-gap="30" data-media-queries='[
@@ -63,8 +60,6 @@
           <p class="g-color-white-opacity-0_7 mb-0">
             {% if team.participation and team.participation.division %}
               {{team.participation.division}}
-            {% elif not team.active %}
-              (Inactive)
             {% else %}
               &nbsp;
             {% endif %}

--- a/src/teams/models/club_team.py
+++ b/src/teams/models/club_team.py
@@ -136,3 +136,22 @@ class ClubTeam(models.Model):
     def current_participation(self):
         participations = self.clubteamseasonparticipation_set.current()
         return participations[0] if participations.exists() else None
+
+    def team_photo_participation(self, previous_seasons=1):
+        """
+        Returns the ClubTeamSeasonParticipation instance to use for displaying a team photo.
+        Uses the current season first, then previous seasons, up to the number of previous_seasons specified.
+
+        Args:
+            previous_seasons (int): The number of previous seasons to check for a team photo if
+                the current season does not have one. Defaults to 1.
+        Returns:
+            ClubTeamSeasonParticipation: The participation instance with a team photo, or None if none found.
+        """
+
+        participations = self.clubteamseasonparticipation_set.order_by('-season__start')[:previous_seasons]
+        for participation in participations:
+            if participation and participation.team_photo:
+                return participation
+
+        return None

--- a/src/teams/views.py
+++ b/src/teams/views.py
@@ -24,7 +24,7 @@ def js_clubteams(active_only=False):
 
 
 class ClubTeamListView(TemplateView):
-    """ View of a list of all CSHC teams. """
+    """ View of a list of all active CSHC teams. """
 
     model = ClubTeam
     template_name = 'teams/clubteam_list.html'
@@ -32,11 +32,10 @@ class ClubTeamListView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super(ClubTeamListView, self).get_context_data(**kwargs)
 
-        all_teams = list(ClubTeam.objects.all())
+        all_teams = list(ClubTeam.objects.active())
 
         for team in all_teams:
-            team.category = 'Inactive' if not team.active else (team.get_gender_display() if (team.long_name.startswith('Men\'s') or team.long_name.startswith('Ladies'))
-                                                                else 'Other')
+            team.category = team.get_gender_display() if (team.long_name.startswith('Men\'s') or team.long_name.startswith('Ladies')) else 'Other'
 
             team.participation = team.team_photo_participation()
 

--- a/src/teams/views.py
+++ b/src/teams/views.py
@@ -38,7 +38,7 @@ class ClubTeamListView(TemplateView):
             team.category = 'Inactive' if not team.active else (team.get_gender_display() if (team.long_name.startswith('Men\'s') or team.long_name.startswith('Ladies'))
                                                                 else 'Other')
 
-            team.participation = team.current_participation()
+            team.participation = team.team_photo_participation()
 
             if team.participation and team.participation.team_photo:
                 photo_url = get_thumbnail_url(


### PR DESCRIPTION
The main change here is to the way team photos are pulled into the "All Teams" list. The previous implementation only pulled photos for the current season, meaning that no photos are displayed until new ones are taken each season (and no photos are displayed right now).

The new code will get team photos from from current and previous seasons, up to a configurable limit, which defaults to one previous season. The most recent photo is used. This makes last season's photo display until a new one is added each season.

The second change is to hide inactive teams from the All Teams list, and remove the indoor teams from the Teams section of the nav bar.