### PR TITLE
Fix Opposition Stats Summaries

### DIFF
--- a/src/core/management/commands/nightly_tasks.py
+++ b/src/core/management/commands/nightly_tasks.py
@@ -49,8 +49,7 @@ class Command(BaseCommand):
 
         try:
             # Update opposition stats
-            update_all_club_stats()
-            print('Updated all opposition club stats')
+            call_command('update_oppo_stats')
         except Exception as e:
             errors.append(
                 "Failed to update Opposition Club Stats: {}".format(e))

--- a/src/core/management/commands/update_oppo_stats.py
+++ b/src/core/management/commands/update_oppo_stats.py
@@ -1,0 +1,47 @@
+""" Management command that updates opposition stats for all clubs or a specific club.
+
+    Usage:
+    python manage.py update_oppo_stats
+    Optional arguments:
+    --club <club_name> : Update stats only for a specific opposition club (e.g., "Newmarket").
+"""
+
+import logging
+from django.core.management.base import BaseCommand
+from competitions.models import Season
+from opposition.stats import update_all_club_stats, update_club_stats_for_club
+from opposition.models import Club
+
+LOG = logging.getLogger(__name__)
+
+class Command(BaseCommand):
+    help = "Updates all opposition stats or stats for a specific club."
+
+    def add_arguments(self, parser):
+        """Adds command line arguments to the management command."""
+        parser.add_argument(
+            '--club',
+            type=str,
+            help='Optional: Update stats only for a specific opposition club (e.g., "Newmarket").',
+        )
+
+    def handle(self, *args, **options):
+        club_name = options.get('club')
+
+        if club_name:
+            LOG.info(f'Updating opposition club stats for: {club_name}')
+            try:
+                club = Club.objects.get(name=club_name)
+                update_club_stats_for_club(club)
+                LOG.info(f'Successfully updated opposition club stats for: {club_name}')
+            except Club.DoesNotExist:
+                LOG.error(f'Club "{club_name}" not found.')
+            except Exception as e:
+                LOG.error(f'Error updating stats for "{club_name}": {e}')
+        else:
+            LOG.info('Updating all opposition club stats')
+            try:
+                update_all_club_stats()
+                LOG.info('Successfully updated all opposition club stats')
+            except Exception as e:
+                LOG.error(f'Error updating all opposition stats: {e}')

--- a/src/opposition/models/club_stats.py
+++ b/src/opposition/models/club_stats.py
@@ -134,7 +134,7 @@ class ClubStats(models.Model):
         """ Returns true if this instance represents the totals for a club
             (rather than being specific to a particular CSHC team).
         """
-        return self.team is None
+        return self.team_id is None
 
     def reset(self):
         """Resets all stats to zero"""

--- a/src/opposition/stats.py
+++ b/src/opposition/stats.py
@@ -4,6 +4,7 @@
 import logging
 from matches.models import Match
 from opposition.models import Club, ClubStats
+from teams.models import ClubTeam
 
 LOG = logging.getLogger(__name__)
 
@@ -40,6 +41,15 @@ def update_club_stats_for_club(club):
     # Reset all the entries
     for stat in s_entries:
         stat.reset()
+
+        if stat.team_id is not None:
+            try:
+                _ = stat.team
+            except ClubTeam.DoesNotExist:
+                LOG.warning("Unable to resolve {} team with ID {}. Removing stats entry {}.".format(club.name, stat.team_id, stat.pk))
+                stat.delete()
+                continue
+
         if not stat.is_club_total():
             s_lookup[stat.team_id] = stat
         else:


### PR DESCRIPTION
The opposition stats update function is broken because there is an existing stats entry for a Newmarket team which is no longer present in the database and the script throws an exception when it reaches it and stops processing any further records.

This has meant that opposition stats summary table for Newmarket and all clubs after it alphabetically has not been working for some time (at least a couple of years). You can verify this by looking at:
* The [Newmarket page](https://cambridgesouthhockeyclub.co.uk/opposition/clubs/newmarket/) - the numbers don't add up correctly when you compare to per-team stats, and the summary table has two "All" entries.
* The [Norwich City page](https://cambridgesouthhockeyclub.co.uk/opposition/clubs/norwich-city/) - the numbers don't add up and the MV game from 2024 is missing in the summary.

A couple of small changes to fix this and improve the process:
1. Check for the team ID rather than trying to resolve the team name when we check to see if this is the totals row - this prevents the exception
2. Detect and remove orphaned stats entries - this gets rid of the duplicate "All" entry

The other changes are just management improvements:
1. Create a management command for updating opposition stats
2. Use the new mgmt command in the nightly_tasks script.

This whole script/function could use being made more robust, but this solves the immediate problem (and will probably make Jan happy).