### PR TITLE
Fix captains list on the committee page

### DIFF
--- a/src/cshc/templates/club_info/committee.html
+++ b/src/cshc/templates/club_info/committee.html
@@ -76,47 +76,4 @@
   {% model_admin_links 'members' 'committeemembership' %}
 </div>
 
-{% subheading "Men's Captains" %}
-
-<div class="row text-center">
-  {% for team in mens_captains %}
-    <div class="col-lg-4">
-      {% include 'club_info/_captain_panel.html' with team=team captain_title="Captain" vice_captain_title="Vice-Captain" %}
-    </div>
-  {% endfor %}
-</div>
-
-{% if ladies_captains %}
-{% subheading "Ladies' Captains" %}
-
-<div class="row text-center">
-  {% for team in ladies_captains %}
-    <div class="col-lg-4">
-      {% include 'club_info/_captain_panel.html' with team=team captain_title="Captain" vice_captain_title="Vice-Captain" %}
-    </div>
-  {% endfor %}
-</div>
-{% endif %}
-
-{% if mixed_captains %}
-{% subheading "Mixed Captains" %}
-
-<div class="row text-center">
-  {% for team in mixed_captains %}
-    <div class="col-lg-4">
-      {# For mixed teams, we assume captain and vice_captain are co-captains #}
-      {% include 'club_info/_captain_panel.html' with team=team captain_title="Co-Captain" vice_captain_title="Co-Captain" %}
-    </div>
-  {% empty %} {# <-- Add empty block for mixed teams #}
-    <div class="col-12 g-mb-20">
-      <p class="lead g-font-style-italic">Mixed team captains not assigned for this season.</p>
-    </div>
-  {% endfor %}
-</div>
-{% endif %}
-
-<div class="g-py-20">
-  {% model_admin_links 'teams' 'teamcaptaincy' %}
-</div>
-
 {% endblock content %}

--- a/src/cshc/templates/club_info/committee.html
+++ b/src/cshc/templates/club_info/committee.html
@@ -81,34 +81,42 @@
 <div class="row text-center">
   {% for team in mens_captains %}
     <div class="col-lg-4">
-      {% include 'club_info/_captain_panel.html' with captain_title="Captain" vice_captain_title="Vice-Captain" %}
+      {% include 'club_info/_captain_panel.html' with team=team captain_title="Captain" vice_captain_title="Vice-Captain" %}
     </div>
   {% endfor %}
 </div>
 
+{% if ladies_captains %}
 {% subheading "Ladies' Captains" %}
 
 <div class="row text-center">
   {% for team in ladies_captains %}
     <div class="col-lg-4">
-      {% include 'club_info/_captain_panel.html' with captain_title="Captain" vice_captain_title="Vice-Captain" %}
+      {% include 'club_info/_captain_panel.html' with team=team captain_title="Captain" vice_captain_title="Vice-Captain" %}
     </div>
   {% endfor %}
 </div>
+{% endif %}
 
+{% if mixed_captains %}
 {% subheading "Mixed Captains" %}
 
 <div class="row text-center">
-  <div class="col-lg-4">
-    {% include 'club_info/_captain_panel.html' with team=mixed_captains captain_title="Mens Co-Captain" vice_captain_title="Ladies Co-Captain" %}
-  </div>
+  {% for team in mixed_captains %}
+    <div class="col-lg-4">
+      {# For mixed teams, we assume captain and vice_captain are co-captains #}
+      {% include 'club_info/_captain_panel.html' with team=team captain_title="Co-Captain" vice_captain_title="Co-Captain" %}
+    </div>
+  {% empty %} {# <-- Add empty block for mixed teams #}
+    <div class="col-12 g-mb-20">
+      <p class="lead g-font-style-italic">Mixed team captains not assigned for this season.</p>
+    </div>
+  {% endfor %}
 </div>
+{% endif %}
 
 <div class="g-py-20">
   {% model_admin_links 'teams' 'teamcaptaincy' %}
 </div>
 
 {% endblock content %}
-
-
-  

--- a/src/cshc/templates/club_info/teamcaptains.html
+++ b/src/cshc/templates/club_info/teamcaptains.html
@@ -1,0 +1,83 @@
+{% extends "base.html" %}
+{% load static %}
+{% load django_bootstrap_breadcrumbs %}
+{% load cshc_tags documents %}
+{% load compress %}
+
+{% block title %}{{ block.super }} | Team Captains{% endblock %}
+
+
+{% block link %}
+  {% compress css %}
+  <link rel="stylesheet" href="{% static "vendor/icon-line-pro/style.css" %}">
+  {% endcompress %}
+{% endblock link %}
+
+{% block breadcrumbs %}
+  {{ block.super }}
+  {% breadcrumb "Captains" "team_captains" %}
+  {% if not is_current_season %}
+  {% breadcrumb season.slug "team_captains" season_slug=season.slug %}
+  {% endif %}
+{% endblock %}
+
+{% block content %}
+
+{% url 'team_captains' as base_captains_url %}
+
+<header class="g-mb-20">
+  <h2 class="h1 g-font-weight-300 text-uppercase">Team Captains
+    {% include 'blocks/_season_selector.html' with base_url=base_captains_url %}
+  </h2>
+</header>
+
+<div class="row">
+  <div class="col-lg-12">
+    <p class="lead">Team captains are elected each year at the Annual General Meeting with appointments running for a single season.</p>
+  </div>
+</div>
+
+{% subheading "Men's Captains" %}
+
+<div class="row text-center">
+  {% for team in mens_captains %}
+    <div class="col-lg-4">
+      {% include 'club_info/_captain_panel.html' with team=team captain_title="Captain" vice_captain_title="Vice-Captain" %}
+    </div>
+  {% endfor %}
+</div>
+
+{% if ladies_captains %}
+{% subheading "Ladies' Captains" %}
+
+<div class="row text-center">
+  {% for team in ladies_captains %}
+    <div class="col-lg-4">
+      {% include 'club_info/_captain_panel.html' with team=team captain_title="Captain" vice_captain_title="Vice-Captain" %}
+    </div>
+  {% endfor %}
+</div>
+{% endif %}
+
+{% if mixed_captains %}
+{% subheading "Mixed Captains" %}
+
+<div class="row text-center">
+  {% for team in mixed_captains %}
+    <div class="col-lg-4">
+      {# For mixed teams, we assume captain and vice_captain are co-captains #}
+      {% include 'club_info/_captain_panel.html' with team=team captain_title="Co-Captain" vice_captain_title="Co-Captain" %}
+    </div>
+  {% empty %} {# <-- Add empty block for mixed teams #}
+    <div class="col-12 g-mb-20">
+      <p class="lead g-font-style-italic">Mixed team captains not assigned for this season.</p>
+    </div>
+  {% endfor %}
+</div>
+{% endif %}
+
+<div class="g-py-20">
+  {% model_admin_links 'teams' 'teamcaptaincy' %}
+</div>
+
+{% endblock content %}

--- a/src/cshc/templates/core/_nav.html
+++ b/src/cshc/templates/core/_nav.html
@@ -94,6 +94,9 @@
                     <li class="dropdown-item {% active_link 'about_committee' %}">
                       <a href="{% url 'about_committee' %}" class="nav-link">Committee</a>
                     </li>
+                    <li class="dropdown-item {% active_link 'team_captains' %}">
+                      <a href="{% url 'team_captains' %}" class="nav-link">Team Captains</a>
+                    </li>
                     <li class="dropdown-item {% active_link 'calendar' %}">
                       <a href="{% url 'calendar' %}" class="nav-link">Calendar</a>
                     </li>

--- a/src/cshc/urls.py
+++ b/src/cshc/urls.py
@@ -25,7 +25,7 @@ from django.conf.urls.static import static
 from core.views import JuniorsContactSubmissionCreateView, ContactSubmissionCreateView
 from members.views import profile
 from venues.views import DirectionsView
-from .views import HomeView, CalendarView, CommitteeSeasonView, templateTestView, CshcGraphQLView
+from .views import HomeView, CalendarView, CommitteeSeasonView, CaptainsSeasonView, templateTestView, CshcGraphQLView
 from .sitemap import CshcSitemap
 
 
@@ -56,6 +56,13 @@ urlpatterns = [
     url(r'^about/committee/(?P<season_slug>[-\w]+)/$',
         CommitteeSeasonView.as_view(),
         name="about_committee_season",
+        ),
+
+    url(r'^about/teamcaptains/$', CaptainsSeasonView.as_view(), name="team_captains"),
+    # E.g. '/about/teamcaptains/2011-2012/'
+    url(r'^about/teamcaptains/(?P<season_slug>[-\w]+)/$',
+        CaptainsSeasonView.as_view(),
+        name="team_captains_season",
         ),
 
     url(r'^archive/minutes/$', TemplateView.as_view(

--- a/src/cshc/views.py
+++ b/src/cshc/views.py
@@ -12,7 +12,7 @@ from training.views import UpcomingTrainingSessionsView
 from core.models import TeamGender
 from core.views import get_season_from_kwargs, add_season_selector
 from competitions.models import Season
-from teams.models import ClubTeam
+from teams.models import ClubTeam, TeamCaptaincy
 from matches.models import Match, Appearance
 from members.models import CommitteeMembership
 from members.utils import member_from_request
@@ -152,58 +152,65 @@ class CommitteeSeasonView(TemplateView):
     """ View for displaying the Club Committee members for a particular season. """
     template_name = 'club_info/committee.html'
 
-    def get_captains(self, committee_list, team_names):
-        """ 
-        Gets a list of team objects with captains and vice-captains populated
-
-        Returns: a list of objects, each with name, captain and vice_captain fields
-        """
-        return [
-            {
-                'name': team_name,
-                'captain': next((m for m in committee_list if m.position.name == "{} Captain".format(team_name)), None),
-                'vice_captain': next((m for m in committee_list if m.position.name == "{} Vice-Captain".format(team_name)), None)
-            } for team_name in team_names
-        ]
-
     def get_context_data(self, **kwargs):
         context = super(CommitteeSeasonView, self).get_context_data(**kwargs)
 
-        # If we're viewing this season's committee we may not have a season_slug keyword arg.
         season = get_season_from_kwargs(kwargs)
+        current_season_obj = Season.current()
 
-        all_members = CommitteeMembership.objects.select_related(
+        all_committee_memberships = CommitteeMembership.objects.select_related(
             'position', 'member', 'season').filter(season=season).order_by('position__index')
 
+        mens_captains_list = []
+        ladies_captains_list = []
+        mixed_captains_list = []
+
+        if season == current_season_obj:
+            participating_teams_qs = ClubTeam.objects.active().order_by('position')
+        else:
+            participating_teams_qs = ClubTeam.objects.filter(
+                clubteamseasonparticipation__season=season
+            ).active().order_by('position').distinct()
+
+        for team in participating_teams_qs:
+            team.name = team.long_name
+
+            captains_qs = TeamCaptaincy.get_captains(team=team, season=season)
+            vice_captains_qs = TeamCaptaincy.get_vice_captains(team=team, season=season)
+
+            if team.gender == TeamGender.Mixed:
+                co_captains = list(captains_qs)
+                if len(co_captains) > 0:
+                    team.captain = co_captains[0]
+                    if len(co_captains) > 1:
+                        team.vice_captain = co_captains[1]
+                    else:
+                        team.vice_captain = None
+                else:
+                    team.captain = None
+                    team.vice_captain = None
+                mixed_captains_list.append(team)
+            else:
+                team.captain = captains_qs.first()
+                team.vice_captain = vice_captains_qs.first()
+                if team.gender == TeamGender.Mens:
+                    mens_captains_list.append(team)
+                elif team.gender == TeamGender.Ladies:
+                    ladies_captains_list.append(team)
+
+        context['mens_captains'] = mens_captains_list
+        context['ladies_captains'] = ladies_captains_list
+        context['mixed_captains'] = mixed_captains_list
+
         context['general_committee'] = [
-            m for m in all_members if m.position.gender == TeamGender.Mixed]
-        ladies_committee = [
-            m for m in all_members if m.position.gender == TeamGender.Ladies]
-        mens_committee = [
-            m for m in all_members if m.position.gender == TeamGender.Mens]
+            m for m in all_committee_memberships
+            if not ("Captain" in m.position.name or "Co-Captain" in m.position.name)
+        ]
 
-        ladies_team_names = list(
-            ClubTeam.objects.ladies().values_list('long_name', flat=True))
-        mens_team_names = list(
-            ClubTeam.objects.mens().values_list('long_name', flat=True))
-
-        context['mens_captains'] = self.get_captains(
-            mens_committee, mens_team_names)
-
-        context['ladies_captains'] = self.get_captains(
-            ladies_committee, ladies_team_names)
-
-        context['mixed_captains'] = {
-            'name': "Mixed XI",
-            'captain': next((m for m in mens_committee if m.position.name == "Men's Mixed XI Co-Captain"), None),
-            'vice_captain': next((m for m in ladies_committee if m.position.name == "Ladies' Mixed XI Co-Captain"), None)
-        }
-
-        season_slug_list = list(CommitteeMembership.objects.order_by(
-            '-season').values_list('season__slug', flat=True).distinct())
-
-        add_season_selector(
-            context, season, season_slug_list)
+        season_slug_list = list(Season.objects.filter(
+            clubteamseasonparticipation__isnull=False
+        ).values_list('slug', flat=True).distinct().order_by('-start'))
+        add_season_selector(context, season, season_slug_list)
 
         return context
 

--- a/src/cshc/views.py
+++ b/src/cshc/views.py
@@ -156,10 +156,31 @@ class CommitteeSeasonView(TemplateView):
         context = super(CommitteeSeasonView, self).get_context_data(**kwargs)
 
         season = get_season_from_kwargs(kwargs)
-        current_season_obj = Season.current()
-
         all_committee_memberships = CommitteeMembership.objects.select_related(
             'position', 'member', 'season').filter(season=season).order_by('position__index')
+
+        context['general_committee'] = [
+            m for m in all_committee_memberships
+            if not ("Captain" in m.position.name or "Co-Captain" in m.position.name)
+        ]
+
+        season_slug_list = list(Season.objects.filter(
+            clubteamseasonparticipation__isnull=False
+        ).values_list('slug', flat=True).distinct().order_by('-start'))
+        add_season_selector(context, season, season_slug_list)
+
+        return context
+
+
+class CaptainsSeasonView(TemplateView):
+    """ View for displaying the Club Captains for a particular season. """
+    template_name = 'club_info/teamcaptains.html'
+
+    def get_context_data(self, **kwargs):
+        context = super(CaptainsSeasonView, self).get_context_data(**kwargs)
+
+        season = get_season_from_kwargs(kwargs)
+        current_season_obj = Season.current()
 
         mens_captains_list = []
         ladies_captains_list = []
@@ -202,18 +223,13 @@ class CommitteeSeasonView(TemplateView):
         context['ladies_captains'] = ladies_captains_list
         context['mixed_captains'] = mixed_captains_list
 
-        context['general_committee'] = [
-            m for m in all_committee_memberships
-            if not ("Captain" in m.position.name or "Co-Captain" in m.position.name)
-        ]
-
         season_slug_list = list(Season.objects.filter(
             clubteamseasonparticipation__isnull=False
         ).values_list('slug', flat=True).distinct().order_by('-start'))
         add_season_selector(context, season, season_slug_list)
 
         return context
-
+    
 
 @user_passes_test(lambda u: u.is_superuser)
 def templateTestView(request, template):

--- a/src/teams/models/team_captaincy.py
+++ b/src/teams/models/team_captaincy.py
@@ -3,33 +3,38 @@
 """
 
 from django.db import models
+from django.db.models.query import QuerySet
 
-
-class TeamCaptaincyManager(models.Manager):
-    """ Queries relating to the TeamCaptaincy model. """
-
-    def get_queryset(self):
-        return super(TeamCaptaincyManager, self).get_queryset().select_related('member', 'team', 'season')
+# 1. Define a custom QuerySet class
+class TeamCaptaincyQuerySet(QuerySet):
+    """ Custom QuerySet for TeamCaptaincy models, providing chainable filtering methods. """
 
     def by_team(self, team):
         """ Returns only entries for the specified team. """
-        return self.get_queryset().filter(team=team)
+        return self.filter(team=team)
 
     def by_member(self, member):
         """ Returns only entries for the specified member. """
-        return self.get_queryset().filter(member=member)
+        return self.filter(member=member)
 
     def by_season(self, season):
         """ Returns only entries for the specified season. """
-        return self.get_queryset().filter(season=season)
+        return self.filter(season=season)
 
     def captains(self):
         """ Returns only captains (as opposed to vice-captains). """
-        return self.get_queryset().filter(is_vice=False)
+        return self.filter(is_vice=False)
 
     def vice_captains(self):
         """ Returns only vice-captains (as opposed to captains). """
-        return self.get_queryset().filter(is_vice=True)
+        return self.filter(is_vice=True)
+
+
+class TeamCaptaincyManager(models.Manager):
+    """ Model Manager for the TeamCaptaincy model. """
+
+    def get_queryset(self):
+        return TeamCaptaincyQuerySet(self.model, using=self._db).select_related('member', 'team', 'season')
 
 
 class TeamCaptaincy(models.Model):
@@ -72,11 +77,11 @@ class TeamCaptaincy(models.Model):
         """ Returns TeamCaptaincy objects corresponding to the captains for
             the specified team and season.
         """
-        return TeamCaptaincy.objects.by_team(team=team).by_season(season).captains()
+        return TeamCaptaincy.objects.all().by_team(team=team).by_season(season).captains()
 
     @staticmethod
     def get_vice_captains(team, season):
         """ Returns TeamCaptaincy objects corresponding to the vice captains for
             the specified team and season.
         """
-        return TeamCaptaincy.objects.by_team(team).by_season(season).vice_captains()
+        return TeamCaptaincy.objects.all().by_team(team).by_season(season).vice_captains()


### PR DESCRIPTION
The captains list on the committee page hasn't been populated for the past few seasons because it looks like we stopped creating captains in the committee table. 

This change uses the current TeamCaptaincy model to pull captains into the page. It does not break the display of captains on team pages.

I have also limited the committee page to only displaying captains for teams which participated (for past seasons) or are active (for the current season), and only sections for which there are teams (e.g., hides ladies' and mixed sections for seasons when there were only men's teams).

UPDATE: Captains are no longer on the committee page, and are now on a separate Captains page, using the same view logic as above