### PR TITLE
Content updates 3

### DIFF
--- a/src/core/views.py
+++ b/src/core/views.py
@@ -51,7 +51,21 @@ def add_season_selector(context, season, season_slug_list):
 
         Returns the updated context.
     """
+    season_slug_list = list(dict.fromkeys(season_slug_list))
+    current_season = Season.current()
+
+    # Some views derive the selector options from historical stats/participation
+    # rows, so the selected/current season can be missing before any data exists.
+    required_slugs = [season.slug, current_season.slug]
+    if any(slug not in season_slug_list for slug in required_slugs):
+        season_slug_list = list(
+            Season.objects.filter(slug__in=season_slug_list + required_slugs)
+            .order_by('-start')
+            .values_list('slug', flat=True)
+        )
+
     context['season'] = season
+    context['current_season'] = current_season
     context['season_slug_list'] = season_slug_list
     context['is_current_season'] = Season.is_current_season(season.id)
     return context

--- a/src/cshc/templates/blocks/_season_selector.html
+++ b/src/cshc/templates/blocks/_season_selector.html
@@ -1,10 +1,19 @@
-<div class="btn-group link-dropdown subtitle-dropdown {{ class }}">
-  <button class="btn btn-link btn-lg dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    {{ season }}
-  </button>
-  <div class="dropdown-menu">
-    {% for season_slug in season_slug_list %}
-    <a class="dropdown-item {% if season_slug == season.slug %}active{% endif %}" href="{{ base_url }}{{ season_slug }}">{{ season_slug }}</a>
-    {% endfor %}
+<div class="season-selector {{ class }}">
+  <div class="dropdown">
+    <button class="btn btn-outline-primary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      {{ season }}
+    </button>
+    <div class="dropdown-menu dropdown-menu-right season-selector__menu">
+      <a class="dropdown-item season-selector__shortcut {% if is_current_season %}active{% endif %}" href="{{ base_url }}">
+        {{ current_season.slug }}
+        <span class="badge badge-light g-ml-5">Current</span>
+      </a>
+      <div class="dropdown-divider"></div>
+      {% for season_slug in season_slug_list %}
+      {% if season_slug != current_season.slug %}
+      <a class="dropdown-item {% if season_slug == season.slug %}active{% endif %}" href="{{ base_url }}{{ season_slug }}">{{ season_slug }}</a>
+      {% endif %}
+      {% endfor %}
+    </div>
   </div>
 </div>

--- a/src/cshc/templates/club_info/committee.html
+++ b/src/cshc/templates/club_info/committee.html
@@ -28,7 +28,7 @@
 {% url 'about_committee' as base_committee_url %}
 
 <header class="g-mb-20">
-  <h2 class="h1 g-font-weight-300 text-uppercase">CSHC Committee and Constitution
+  <h2 class="h1 g-font-weight-300 text-uppercase">Committee
     {% include 'blocks/_season_selector.html' with base_url=base_committee_url %}
   </h2>
 </header>
@@ -67,7 +67,7 @@
     </div>
   {% empty %}
     <div class="col-12 g-mb-20">
-      <p class="lead g-font-style-italic">Committee positions not know for this season.</p>
+      <p class="lead g-font-style-italic">Committee positions not known for this season.</p>
     </div>
   {% endfor %}
 </div>

--- a/src/cshc/templates/club_info/committee.html
+++ b/src/cshc/templates/club_info/committee.html
@@ -27,10 +27,9 @@
 {% url 'about_minutes' as minutes_url %}
 {% url 'about_committee' as base_committee_url %}
 
-<header class="g-mb-20">
-  <h2 class="h1 g-font-weight-300 text-uppercase">Committee
-    {% include 'blocks/_season_selector.html' with base_url=base_committee_url %}
-  </h2>
+<header class="g-mb-20 d-flex flex-column flex-md-row justify-content-between align-items-md-center">
+  <h2 class="h1 g-font-weight-300 text-uppercase g-mb-10 g-mb-md-0">Committee</h2>
+  {% include 'blocks/_season_selector.html' with base_url=base_committee_url %}
 </header>
 
 <div class="row">

--- a/src/cshc/templates/club_info/teamcaptains.html
+++ b/src/cshc/templates/club_info/teamcaptains.html
@@ -25,10 +25,9 @@
 
 {% url 'team_captains' as base_captains_url %}
 
-<header class="g-mb-20">
-  <h2 class="h1 g-font-weight-300 text-uppercase">Team Captains
-    {% include 'blocks/_season_selector.html' with base_url=base_captains_url %}
-  </h2>
+<header class="g-mb-20 d-flex flex-column flex-md-row justify-content-between align-items-md-center">
+  <h2 class="h1 g-font-weight-300 text-uppercase g-mb-10 g-mb-md-0">Team Captains</h2>
+  {% include 'blocks/_season_selector.html' with base_url=base_captains_url %}
 </header>
 
 <div class="row">

--- a/src/cshc/templates/core/_nav.html
+++ b/src/cshc/templates/core/_nav.html
@@ -36,7 +36,7 @@
                   <h4 class="h5 text-uppercase g-font-weight-600">{{ team.title }}</h4>
                   <ul class="list-unstyled">
                     {% for item in team.list %}
-                    <li class="dropdown-item {% active_link 'clubteam_detail' item.0 %}{% if item.2 %} g-brd-top g-brd-gray-dark-v3{% endif %}">
+                    <li class="dropdown-item {% if season_slug and season_slug != 'All seasons' %}{% active_link 'clubteam_season_detail' item.0 season_slug %}{% else %}{% active_link 'clubteam_detail' item.0 %}{% endif %}{% if item.2 %} g-brd-top g-brd-gray-dark-v3{% endif %}">
                       <a href="{% url 'clubteam_detail' item.0 %}" class="nav-link">{{ item.1 }}</a>
                     </li>
                     {% endfor %}
@@ -94,10 +94,10 @@
                     <li class="dropdown-item {% active_link 'zinnia:entry_archive_index' %}">
                       <a href="{% url 'zinnia:entry_archive_index' %}" class="nav-link">News</a>
                     </li>
-                    <li class="dropdown-item {% active_link 'about_committee' %}">
+                    <li class="dropdown-item {% if season_slug and season_slug != 'All seasons' %} {% active_link 'about_committee_season' season_slug %}{% else %}{% active_link 'about_committee' %}{% endif %}">
                       <a href="{% url 'about_committee' %}" class="nav-link">Committee</a>
                     </li>
-                    <li class="dropdown-item {% active_link 'team_captains' %}">
+                    <li class="dropdown-item {% if season_slug and season_slug != 'All seasons' %} {% active_link 'team_captains_season' season_slug %}{% else %}{% active_link 'team_captains' %}{% endif %}">
                       <a href="{% url 'team_captains' %}" class="nav-link">Team Captains</a>
                     </li>
                     <li class="dropdown-item {% active_link 'calendar' %}">
@@ -138,19 +138,19 @@
             <li class="dropdown-item {% active_link 'playing_record' %}">
               <a href="{% url 'playing_record' %}" class="nav-link">Team Playing Records</a>
             </li>
-            <li class="dropdown-item {% active_link 'goal_king' %}">
+            <li class="dropdown-item {% if season_slug and season_slug != 'All seasons' %}{% active_link 'goal_king_season' season_slug %}{% else %}{% active_link 'goal_king' %}{% endif %}">
               <a href="{% url 'goal_king' %}" class="nav-link">Goal King</a>
             </li>
-            <li class="dropdown-item {% active_link 'southerners_league' %}">
+            <li class="dropdown-item {% if season_slug and season_slug != 'All seasons' %}{% active_link 'southerners_league_season' season_slug %}{% else %}{% active_link 'southerners_league' %}{% endif %}">
               <a href="{% url 'southerners_league' %}" class="nav-link">Southerners League</a>
             </li>
             <li class="dropdown-item {% active_link 'opposition_club_list' %}">
               <a href="{% url 'opposition_club_list' %}" class="nav-link">Rivals</a>
             </li>
-            <li class="dropdown-item {% active_link 'accidental_tourist' %}">
+            <li class="dropdown-item {% if season_slug and season_slug != 'All seasons' %}{% active_link 'accidental_tourist_season' season_slug %}{% else %}{% active_link 'accidental_tourist' %}{% endif %}">
               <a href="{% url 'accidental_tourist' %}" class="nav-link">Accidental Tourist</a>
             </li>
-            <li class="dropdown-item {% active_link 'naughty_step' %}">
+            <li class="dropdown-item {% if season_slug and season_slug != 'All seasons' %}{% active_link 'naughty_step_season' season_slug %}{% else %}{% active_link 'naughty_step' %}{% endif %}">
               <a href="{% url 'naughty_step' %}" class="nav-link">The Naughty Step</a>
             </li>
             <li class="dropdown-item {% active_link 'end_of_season_award_winners_list' %}">

--- a/src/cshc/templates/matches/accidental_tourist.html
+++ b/src/cshc/templates/matches/accidental_tourist.html
@@ -23,10 +23,9 @@
 
 {% url 'accidental_tourist' as base_accidental_tourist_url %}
 
-<header class="g-mb-20">
-  <h2 class="h1 g-font-weight-300 text-uppercase">Accidental Tourist
-    {% include 'blocks/_season_selector.html' with class='g-mt-7 g-ml-10' base_url=base_accidental_tourist_url %}
-  </h2>
+<header class="g-mb-20 d-flex flex-column flex-md-row justify-content-between align-items-md-center">
+  <h2 class="h1 g-font-weight-300 text-uppercase g-mb-10 g-mb-md-0">Accidental Tourist</h2>
+  {% include 'blocks/_season_selector.html' with base_url=base_accidental_tourist_url %}
 </header>
 
 <p class="lead">This table shows the total miles and miles-per-game travelled by each player during the season.</p>

--- a/src/cshc/templates/matches/goalking.html
+++ b/src/cshc/templates/matches/goalking.html
@@ -23,10 +23,9 @@
 
   {% url 'goal_king' as base_goal_king_url %}
 
-  <header class="g-mb-20">
-    <h2 class="h1 g-font-weight-300 text-uppercase">Goal King
-      {% include 'blocks/_season_selector.html' with class='g-mt-7 g-ml-10' base_url=base_goal_king_url %}
-    </h2>
+  <header class="g-mb-20 d-flex flex-column flex-md-row justify-content-between align-items-md-center">
+    <h2 class="h1 g-font-weight-300 text-uppercase g-mb-10 g-mb-md-0">Goal King</h2>
+    {% include 'blocks/_season_selector.html' with base_url=base_goal_king_url %}
   </header>
   
   <p class="lead">This table includes all goals scored outdoors and indoors in competitive and friendly matches against external teams.</p>

--- a/src/cshc/templates/matches/naughty_step.html
+++ b/src/cshc/templates/matches/naughty_step.html
@@ -25,20 +25,25 @@ This displays the red, yellow and green cards received by all players.
 
 {% block content %}
 
-<header class="g-mb-20">
-    <h2 class="h1 g-font-weight-300 text-uppercase">The Naughty Step
-      <div class="btn-group link-dropdown subtitle-dropdown g-mt-7 g-ml-10">
-        <button class="btn btn-link btn-lg dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          {{ season_slug }}
-        </button>
-        <div class="dropdown-menu">
-          {% for s in season_slug_list %}
-          <a class="dropdown-item {% if s == season_slug %}active{% endif %}" href="{% url 'naughty_step' %}{% if s != "All seasons" %}{{ s }}{% endif %}">{{s}}</a>
-          {% endfor %}
-        </div>
+<header class="g-mb-20 d-flex flex-column flex-md-row justify-content-between align-items-md-center">
+  <h2 class="h1 g-font-weight-300 text-uppercase g-mb-10 g-mb-md-0">The Naughty Step</h2>
+  <div class="season-selector">
+    <div class="dropdown">
+      <button class="btn btn-outline-primary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        {{ season_slug }}
+      </button>
+      <div class="dropdown-menu dropdown-menu-right season-selector__menu">
+        <a class="dropdown-item season-selector__shortcut {% if season_slug == 'All seasons' %}active{% endif %}" href="{% url 'naughty_step' %}">All seasons</a>
+        <div class="dropdown-divider"></div>
+        {% for s in season_slug_list %}
+        {% if s != 'All seasons' %}
+        <a class="dropdown-item {% if s == season_slug %}active{% endif %}" href="{% url 'naughty_step_season' s %}">{{ s }}</a>
+        {% endif %}
+        {% endfor %}
       </div>
-    </h2>
-  </header>
+    </div>
+  </div>
+</header>
   
 
 

--- a/src/cshc/templates/teams/clubteam_detail.html
+++ b/src/cshc/templates/teams/clubteam_detail.html
@@ -30,8 +30,8 @@
 
   {% url 'clubteam_detail' team.slug as base_team_url %}
 
-  <div class="g-pb-10 d-flex justify-content-between align-items-baseline">
-    <div class="d-flex flex-wrap align-items-baseline">
+  <div class="g-pb-10 d-flex flex-column flex-md-row justify-content-between align-items-md-center">
+    <div class="d-flex flex-wrap align-items-baseline g-mb-10 g-mb-md-0">
       <div class="btn-group link-dropdown title-dropdown">
         <button class="btn btn-link btn-lg dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           {{ team.long_name }}
@@ -45,9 +45,9 @@
           {% endfor %}
         </div>
       </div>
-      {% include 'blocks/_season_selector.html' with base_url=base_team_url %}
     </div>
-    <div>
+    <div class="d-flex flex-column flex-sm-row align-items-sm-center">
+      {% include 'blocks/_season_selector.html' with class='g-mb-10 g-mb-sm-0 g-mr-sm-3' base_url=base_team_url %}
       <a class="g-mx-5" href="{{ ical_url }}" title="{{ team.long_name }} calendar" target="_blank">
         <i class="far fa-lg fa-calendar-alt"></i>
       </a>

--- a/src/cshc/templates/teams/southerners_league.html
+++ b/src/cshc/templates/teams/southerners_league.html
@@ -22,10 +22,9 @@
 
 {% url 'southerners_league' as base_league_url %}
 
-<header class="g-mb-20">
-  <h2 class="h1 g-font-weight-300 text-uppercase">Southerners League
-    {% include 'blocks/_season_selector.html' with class='g-mt-7 g-ml-10' base_url=base_league_url %}
-  </h2>
+<header class="g-mb-20 d-flex flex-column flex-md-row justify-content-between align-items-md-center">
+  <h2 class="h1 g-font-weight-300 text-uppercase g-mb-10 g-mb-md-0">Southerners League</h2>
+  {% include 'blocks/_season_selector.html' with base_url=base_league_url %}
 </header>
 
 <div class="row g-mb-40">

--- a/src/cshc/templates/training/payandplay.html
+++ b/src/cshc/templates/training/payandplay.html
@@ -127,18 +127,18 @@
                   <td>Mondays</td>
                   <td>7.30-8.30pm</td>
                   <td>Mixed, split into higher and lower</td>
-                  <td>Half pitch</td>
+                  <td>Two half pitches</td>
                 </tr>
                 <tr>
                   <td>Wednesdays</td>
                   <td>7.30-8.30pm</td>
                   <td>Mixed, split into higher and lower</td>
-                  <td>Half pitch</td>
+                  <td>Two half pitches</td>
                 </tr>
                 <tr>
                   <td>Thursdays</td>
                   <td>7.30-8.30pm</td>
-                  <td>Men's higher teams (M1-M3)</td>
+                  <td>Men's higher teams (M1-M4)</td>
                   <td>Half pitch</td>
                 </tr>
                 <tr>

--- a/src/cshc/templates/training/trainingsession_list.html
+++ b/src/cshc/templates/training/trainingsession_list.html
@@ -80,7 +80,7 @@
               <tbody>
                 <tr>
                   <td>L1s</td>
-                  <td>Thursdays (fortnightly*)</td>
+                  <td>Thursdays</td>
                   <td>7-8pm</td>
                   <td><a href="{{ long_road_url }}">Long Road</a></td>
                 </tr>
@@ -106,7 +106,6 @@
             </table>
           </div>
         </div>
-        <p class="text-muted text-center"><em>*Check the <a href="{{ calendar }}" title="Calendar">calendar</a> for session dates.</em></p>
       </div>
       <div class="col-md-6 align-self-center g-py-20 order-2 order-md-2">
       {% abs_static_url "img/ladies_training20250810.jpg" as ladies_training_image %}

--- a/src/frontend/js/components/common/Loading/index.jsx
+++ b/src/frontend/js/components/common/Loading/index.jsx
@@ -5,11 +5,9 @@ import PropTypes from 'prop-types';
  * Loading/spinner component - typically displayed while fetching GraphQL data using Apollo.
  */
 const Loading = ({ message }) => (
-  <div className="g-mb-20 g-mt-20 g-flex-centered">
-    <div className="g-flex-centered-item g-text-center">
-      <i className="fas fa-spinner fa-spin" />
-      {message && <span className="g-ml-5">{message}</span>}
-    </div>
+  <div className="text-center g-py-50">
+    <i className="fas fa-spinner fa-spin fa-3x g-color-primary"></i>
+    {message && <p className="g-mt-20">{message}</p>}
   </div>
 );
 

--- a/src/frontend/js/components/matches/MatchList/MatchListWrapper/MatchListWrapper.jsx
+++ b/src/frontend/js/components/matches/MatchList/MatchListWrapper/MatchListWrapper.jsx
@@ -66,7 +66,7 @@ MatchListWrapper.propTypes = {
 MatchListWrapper.defaultProps = {
   pageSize: 20,
   page: 1,
-  orderBy: undefined,
+  orderBy: '-date',
   gender: undefined,
   team: undefined,
   opposition: undefined,

--- a/src/frontend/js/components/matches/MatchListDisplay/MatchListDisplay.jsx
+++ b/src/frontend/js/components/matches/MatchListDisplay/MatchListDisplay.jsx
@@ -9,20 +9,14 @@ import OppositionTeam from 'components/matches/OppositionTeam';
 import MatchVenue from 'components/matches/MatchVenue';
 import MatchDate from 'components/matches/MatchDate';
 import MatchLink from 'components/matches/MatchLink';
+import Loading from 'components/common/Loading';
 import UrlSyncedReactTable from 'components/common/UrlSyncedReactTable';
 import commonStyles from 'components/common/style.scss';
 
 class MatchListDisplay extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      loading: !this.props.matches && this.props.networkStatus === NS.loading,
-    };
     this.onSortedChange = this.onSortedChange.bind(this);
-  }
-
-  componentWillReceiveProps(nextProps) {
-    this.setState({ loading: nextProps.networkStatus === NS.loading });
   }
 
   onSortedChange(newSorted) {
@@ -32,12 +26,21 @@ class MatchListDisplay extends React.Component {
 
   render() {
     const {
+      networkStatus,
       matches,
       queryVariables: { pageSize, page },
       onChangePage,
       onChangeUrlQueryParams,
     } = this.props;
-    const { loading } = this.state;
+    const isLoading = 
+      networkStatus === NS.loading ||
+      networkStatus === NS.setVariables ||
+      networkStatus === NS.refetch;
+
+    if (isLoading) {
+      return <Loading message="Loading matches..." />;
+    }
+
     return (
       <div className={commonStyles.reactTable}>
         <UrlSyncedReactTable
@@ -113,7 +116,7 @@ class MatchListDisplay extends React.Component {
             },
           ]}
           data={matches ? matches.results : []}
-          loading={loading}
+          loading={false}
           page={page}
           pageSize={pageSize}
           minRows={matches && matches.length > 0 ? 0 : 5}

--- a/src/frontend/js/components/members/MemberList/MemberListWrapper/MemberListWrapper.jsx
+++ b/src/frontend/js/components/members/MemberList/MemberListWrapper/MemberListWrapper.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import GoogleMap from 'components/common/GoogleMap';
+import Loading from 'components/common/Loading';
 import { ViewType } from 'util/constants';
 import { ViewSwitcher, ViewSwitcherView } from 'components/common/ViewSwitcher';
 import MemberTable from './MemberTable';
@@ -30,12 +31,7 @@ const MemberListWrapper = ({
           <ViewSwitcherView iconClass="far fa-map" label={ViewType.Map} />
         </ViewSwitcher>
       ) : null}
-      {isLoading && (
-        <div className="text-center g-py-50">
-          <i className="fas fa-spinner fa-spin fa-3x g-color-primary"></i>
-          <p className="g-mt-20">Loading members ...</p>
-        </div>
-      )}
+      {isLoading && <Loading message="Loading members..." />}
       {!isLoading && hasData && (!canViewMap || viewType === ViewType.List) ? (
         <MemberTable 
           members={data.results} 

--- a/src/matches/views.py
+++ b/src/matches/views.py
@@ -348,6 +348,7 @@ class NaughtyStepSeasonView(TemplateView):
 
         query = Q(red_card=True) | Q(yellow_card_count__gt=0) | Q(green_card_count__gt=0)
         qs = Appearance.objects.select_related('match', 'member').filter(query)
+        current_season = Season.current()
 
         season_slug = kwargs_or_none('season_slug', **kwargs)
         if season_slug is not None:
@@ -360,6 +361,12 @@ class NaughtyStepSeasonView(TemplateView):
 
         seasons = reduce(lambda l, x: l +
                          [x] if x not in l else l, season_list, [])
+        if current_season.slug not in seasons:
+            seasons = list(
+                Season.objects.filter(slug__in=seasons + [current_season.slug])
+                .order_by('-start')
+                .values_list('slug', flat=True)
+            )
 
         players = {}
         for app in card_apps:
@@ -377,6 +384,8 @@ class NaughtyStepSeasonView(TemplateView):
         context['players'] = players
 
         context['season_slug'] = season_slug if season_slug else 'All seasons'
+        context['current_season'] = current_season
+        context['is_current_season'] = season_slug == current_season.slug
         context['season_slug_list'] = ['All seasons'] + seasons
         return context
 

--- a/src/static/css/core.css
+++ b/src/static/css/core.css
@@ -1,3 +1,8 @@
+html {
+  overflow-y: scroll;
+  scrollbar-gutter: stable;
+}
+
 body {
   background-color: #111;
 }

--- a/src/static/css/core.css
+++ b/src/static/css/core.css
@@ -248,5 +248,5 @@ p > a {
 }
 
 .hs-mega-menu.animated.fadeOut {
-  animation-duration: 0.0s !important;
+  animation-duration: 0.01s !important;
 }

--- a/src/static/css/core.css
+++ b/src/static/css/core.css
@@ -141,6 +141,46 @@ main {
 .btn-group.link-dropdown .btn-link:hover {
   text-decoration: none;
 }
+.season-selector {
+  display: flex;
+  justify-content: flex-end;
+}
+.season-selector .btn {
+  white-space: nowrap;
+}
+.season-selector__menu {
+  max-height: 20rem;
+  overflow-y: auto;
+}
+.season-selector__shortcut {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background-color: #f8f9fa;
+  color: #212529;
+}
+.season-selector__shortcut.active,
+.season-selector__shortcut:active {
+  background-color: #f8f9fa;
+  color: #212529;
+}
+.season-selector__shortcut:hover,
+.season-selector__shortcut:focus {
+  background-color: #f8f9fa;
+  color: #212529;
+}
+.season-selector__shortcut.active:hover,
+.season-selector__shortcut.active:focus,
+.season-selector__shortcut:active:hover,
+.season-selector__shortcut:active:focus {
+  background-color: #f8f9fa;
+  color: #212529;
+}
+@media (max-width: 767.98px) {
+  .season-selector {
+    justify-content: flex-start;
+  }
+}
 .form-control-feedback ul {
   list-style: none;
   padding-left: 0;


### PR DESCRIPTION
Various content updates and of improvements:
* Men's higher PnP is M1-4
* L1s extra session is weekly
* Remove "Constitution" from the committee page heading
* Fix a CSS issue which stopped the menus from disappearing
* Add a common spinner and use it on the member and match lists
* Make matches sort in reverse date order by default (newest first)
* Reserve space for the vertical scrollbar so the page content doesn't jump if/when it is needed
* Highlight navbar items when season slugs are in the URLs
* Improve the season selector on all pages where it is used