### PR TITLE
107: Do not email admins for every stalled POST request

### DIFF
--- a/src/core/logging.py
+++ b/src/core/logging.py
@@ -1,0 +1,30 @@
+# -*- mode: python; coding: utf-8; -*-
+"""Logging handlers."""
+
+from django.http import UnreadablePostError
+from django.utils.log import AdminEmailHandler
+
+
+class FilteredAdminEmailHandler(AdminEmailHandler):
+    """Filter log records prior to sending emails.
+
+    The default `AdminEmailHandler` sends emails that we don't really
+    care about, e.g. stalled connections can elicit many
+    `UnreadablePostError` emails.
+
+    `FilteredAdminEmailHandler` is a small adaptor class that adds
+    filtering to the log stream.  It should be attached to
+    `django.request` with `propagate` set to `False`.
+
+    """
+
+    def emit(self, record):
+        # filter -- ignore UnreadablePostError exceptions
+        if (
+                record.exc_info is not None and
+                record.exc_info[0] is UnreadablePostError
+        ):
+            return
+
+        # pass to super class
+        super().emit(record)

--- a/src/cshc/settings/base.py
+++ b/src/cshc/settings/base.py
@@ -325,9 +325,18 @@ LOGGING = {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
             'formatter': 'verbose'
-        }
+        },
+        'mail_admins': {
+            'level': 'ERROR',
+            'class': 'core.logging.FilteredAdminEmailHandler',
+        },
     },
     'loggers': {
+        'django.request': {
+            'level': 'ERROR',
+            'handlers': ['console', 'mail_admins'],
+            'propagate': False,
+        },
         'django.db.backends': {
             'level': 'ERROR',
             'handlers': ['console'],

--- a/src/cshc/urls.py
+++ b/src/cshc/urls.py
@@ -103,6 +103,8 @@ urlpatterns = [
     url(r'^sitemap-(?P<section>.+)\.xml$', sitemap_views.sitemap,
         {'sitemaps': CshcSitemap}, name='django.contrib.sitemaps.views.sitemap'),
 
+    # development and testing
+    url(r'^devtest/', include('devtest.urls')),
 
 ] + \
     static(settings.STATIC_URL, document_root=settings.STATIC_ROOT) + \

--- a/src/devtest/urls.py
+++ b/src/devtest/urls.py
@@ -1,0 +1,12 @@
+# -*- mode: python; coding: utf-8; -*-
+"""Development and testing URLs."""
+
+from django.conf.urls import url
+
+from . import views
+
+
+#pylint: disable=C0103
+urlpatterns = [
+    url(r'^unreadable_post_error$', views.unreadable_post_error),
+]

--- a/src/devtest/views.py
+++ b/src/devtest/views.py
@@ -1,0 +1,8 @@
+# -*- mode: python; coding: utf-8; -*-
+"""Useful development and testing views."""
+
+from django.http import UnreadablePostError
+
+
+def unreadable_post_error(request):
+    raise UnreadablePostError("simulated unreadable post error")


### PR DESCRIPTION
Requests from the Baidu spider seem to regularly timeout.  When this happens for a `POST /graphql` request, it causes an `UnreadablePostError` exception in the framework.  This exception propagates up to the default AdminEmailHandler, with predictable results.

This commit introduces a new `FilteredAdminEmailHandler` which ignores `UnreadablePostError`exceptions.  When bound to `django.request` (with propagation disabled) these problematic exceptions are ignored.

There is a new `/devtest/unreadable_post_error` endpoint to aid debugging and testing.  Call it with a command line like `curl http://localhost:8000/devtest/unreadable_post_error -d foo` and it will raise an `UnreadablePostError` exception.

The new `FilteredAdminEmailHandler` does not replace the built-in `AdminEmailHandler`.  `AdminEmailHandler` is still attached to the `django` logger automatically and still sends emails for all non-HTTP errors and non-`UnreadablePostError`s.  `django.request` is the logger used for `UnreadablePostError` exceptions, so we attach `FilteredAdminEmailHandler` there.  We also disable propagation to prevent the log records propagating up to the `django` logger and `AdminEmailHandler` handler.