### PR TITLE
Suppress unreadablepost errors

### DIFF
--- a/src/cshc/settings/base.py
+++ b/src/cshc/settings/base.py
@@ -6,7 +6,6 @@ from easy_thumbnails.conf import Settings as thumbnail_settings
 # Normally you should not import ANYTHING from Django directly
 # into your settings, but ImproperlyConfigured is an exception.
 from django.core.exceptions import ImproperlyConfigured
-from raven.transport.threaded_requests import ThreadedRequestsHTTPTransport
 
 
 def get_env_setting(setting):
@@ -207,7 +206,6 @@ THIRD_PARTY_APPS = [
     'sorl.thumbnail',
     'tagging',
     'taggit',
-    'raven.contrib.django.raven_compat',
     'webpack_loader',
     'zinnia',
 ]
@@ -518,20 +516,6 @@ TEMPLATED_EMAIL_FILE_EXTENSION = 'html'
 
 # ########## END django-templated-email CONFIGURATION
 
-# ########## raven CONFIGURATION
-
-# Ref: https://sentry.io/onboarding/cambridge-south-hockey-club/cshc-django/configure/python-django
-RAVEN_CONFIG = {
-    'dsn': get_env_setting('SENTRY_DNS'),
-    'release': VERSION,
-    'transport': ThreadedRequestsHTTPTransport,
-    'ignore_exceptions': [
-        'django.http.request.UnreadablePostError',
-        'django.http.UnreadablePostError',
-    ],
-}
-
-# ########## END raven CONFIGURATION
 
 # ########## Zinnia CONFIGURATION
 

--- a/src/cshc/settings/base.py
+++ b/src/cshc/settings/base.py
@@ -328,6 +328,11 @@ LOGGING = {
         }
     },
     'loggers': {
+        'django.request': {
+            'level': 'ERROR',
+            'handlers': ['console'],
+            'propagate': False, 
+        },
         'django.db.backends': {
             'level': 'ERROR',
             'handlers': ['console'],
@@ -518,6 +523,10 @@ TEMPLATED_EMAIL_FILE_EXTENSION = 'html'
 RAVEN_CONFIG = {
     'dsn': get_env_setting('SENTRY_DNS'),
     'release': VERSION,
+    'ignore_exceptions': [
+        'django.http.request.UnreadablePostError',
+        'django.http.UnreadablePostError',
+    ],
 }
 
 # ########## END raven CONFIGURATION

--- a/src/cshc/settings/base.py
+++ b/src/cshc/settings/base.py
@@ -6,6 +6,7 @@ from easy_thumbnails.conf import Settings as thumbnail_settings
 # Normally you should not import ANYTHING from Django directly
 # into your settings, but ImproperlyConfigured is an exception.
 from django.core.exceptions import ImproperlyConfigured
+from raven.transport.threaded_requests import ThreadedRequestsHTTPTransport
 
 
 def get_env_setting(setting):
@@ -523,6 +524,7 @@ TEMPLATED_EMAIL_FILE_EXTENSION = 'html'
 RAVEN_CONFIG = {
     'dsn': get_env_setting('SENTRY_DNS'),
     'release': VERSION,
+    'transport': ThreadedRequestsHTTPTransport,
     'ignore_exceptions': [
         'django.http.request.UnreadablePostError',
         'django.http.UnreadablePostError',

--- a/src/cshc/settings/production.py
+++ b/src/cshc/settings/production.py
@@ -3,6 +3,7 @@
 import sys
 import os
 from cshc.settings.base import *
+from raven.transport.threaded_requests import ThreadedRequestsHTTPTransport
 
 DEBUG = False
 
@@ -85,3 +86,21 @@ from .common.ckeditor import get_ckeditor_config
 CKEDITOR_CONFIGS = get_ckeditor_config(STATIC_URL)
 
 DBBACKUP_HOSTNAME = 'cambridgesouthhockeyclub.co.uk'
+
+# ########## Raven CONFIGURATION
+INSTALLED_APPS += [
+    'raven.contrib.django.raven_compat',
+]
+
+# Ref: https://sentry.io/onboarding/cambridge-south-hockey-club/cshc-django/configure/python-django
+RAVEN_CONFIG = {
+    'dsn': get_env_setting('SENTRY_DNS'),
+    'release': VERSION,
+    'transport': ThreadedRequestsHTTPTransport,
+    'ignore_exceptions': [
+        'django.http.request.UnreadablePostError',
+        'django.http.UnreadablePostError',
+    ],
+}
+
+# ########## END Raven CONFIGURATION

--- a/src/cshc/urls.py
+++ b/src/cshc/urls.py
@@ -103,6 +103,8 @@ urlpatterns = [
     url(r'^sitemap-(?P<section>.+)\.xml$', sitemap_views.sitemap,
         {'sitemaps': CshcSitemap}, name='django.contrib.sitemaps.views.sitemap'),
 
+    # development and testing
+    url(r'^devtest/', include('devtest.urls')),
 
 ] + \
     static(settings.STATIC_URL, document_root=settings.STATIC_ROOT) + \

--- a/src/devtest/urls.py
+++ b/src/devtest/urls.py
@@ -1,0 +1,14 @@
+# -*- mode: python; coding: utf-8; -*-
+"""Development and testing URLs."""
+
+from django.conf.urls import url
+from django.views.decorators.csrf import csrf_exempt
+
+
+from . import views
+
+
+#pylint: disable=C0103
+urlpatterns = [
+    url(r'^unreadable_post_error$', csrf_exempt(views.unreadable_post_error)),
+]

--- a/src/devtest/views.py
+++ b/src/devtest/views.py
@@ -1,0 +1,8 @@
+# -*- mode: python; coding: utf-8; -*-
+"""Useful development and testing views."""
+
+from django.http import UnreadablePostError
+
+
+def unreadable_post_error(request):
+    raise UnreadablePostError("simulated unreadable post error")


### PR DESCRIPTION
Alternative solution to #107. 
* Suppresses the `UnreadablePost` error alerts at the Raven client
* Fixes Sentry logging by changing the transport
* Moves the Raven configuration to the prod config to avoid nose from dev environments